### PR TITLE
Start phase 5 implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,8 @@ src/
 ## 現在のステータス
 
 - **バージョン**: 0.0.1（開発中）
-- **状態**: Phase 4（アプリケーション層の実装）完了
-- **次のステップ**: Phase 5（インフラストラクチャ層の実装）へ
+- **状態**: Phase 5（インフラストラクチャ層の実装）完了
+- **次のステップ**: Phase 6（インターフェース層の実装）へ
 
 ### 完了済みフェーズ
 
@@ -207,6 +207,14 @@ src/
   - ChangeTaskStatusUseCase: ステータス変更（チェックボックス連動）
   - GetConfigUseCase: 設定取得
   - 25件のユニットテスト（計133件）
+
+- ✅ Phase 5: インフラストラクチャ層の実装
+  - VscodeDocumentClient: VSCodeドキュメント操作（WorkspaceEdit API含む）
+  - VscodeConfigClient: VSCode設定APIのラッパー
+  - MarkdownTaskRepository: TaskRepositoryの実装
+  - VscodeConfigProvider: ConfigProviderの実装（VSCode設定）
+  - FrontmatterConfigProvider: ConfigProviderの実装（フロントマター）
+  - 38件のユニットテスト（計171件）
 
 ---
 

--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -169,7 +169,7 @@ src/
 
 ---
 
-### Phase 5: インフラストラクチャ層の実装
+### Phase 5: インフラストラクチャ層の実装 ✅
 
 **目標**: 外部システム（VSCode API、ファイルシステム）との連携を実装
 
@@ -177,14 +177,18 @@ src/
 
 - [x] `RemarkClient` - remark/AST操作のラッパー（Phase 3で実装済み）
 - [x] `MarkdownTaskClient` - Markdownパース・編集（Phase 3で実装済み）
-- [ ] `VscodeDocumentClient` - VSCodeドキュメント操作
-- [ ] `VscodeWorkspaceClient` - WorkspaceEdit API操作
+- [x] `VscodeDocumentClient` - VSCodeドキュメント操作（WorkspaceEdit API含む）
+- [x] `VscodeConfigClient` - VSCode設定APIのラッパー
 
 #### 5.2 Adapter実装（Portの実装）
 
-- [ ] `MarkdownTaskRepository` - TaskRepositoryの実装（MarkdownTaskClientを使用）
-- [ ] `VscodeConfigProvider` - ConfigProviderの実装（VSCode設定）
-- [ ] `FrontmatterConfigProvider` - ConfigProviderの実装（フロントマター）
+- [x] `MarkdownTaskRepository` - TaskRepositoryの実装（MarkdownTaskClientを使用）
+- [x] `VscodeConfigProvider` - ConfigProviderの実装（VSCode設定）
+- [x] `FrontmatterConfigProvider` - ConfigProviderの実装（フロントマター）
+
+#### 5.3 テスト
+
+- [x] 38件のユニットテストを追加（計171件）
 
 ---
 
@@ -341,8 +345,9 @@ vscode.postMessage({ type: 'UPDATE_TASK', payload: { id, status } });
 2. ~~TDDでドメイン層を実装~~ ✅
 3. ~~Phase 3: Markdownパーサーの実装~~ ✅
 4. ~~Phase 4: アプリケーション層の実装~~ ✅
-5. Phase 5: インフラストラクチャ層の実装
-6. 各フェーズ完了後にレビュー・調整
+5. ~~Phase 5: インフラストラクチャ層の実装~~ ✅
+6. Phase 6: インターフェース層の実装
+7. 各フェーズ完了後にレビュー・調整
 
 ---
 

--- a/src/infrastructure/adapters/frontmatterConfigProvider.test.ts
+++ b/src/infrastructure/adapters/frontmatterConfigProvider.test.ts
@@ -1,0 +1,154 @@
+import { err, ok } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import type { ConfigProvider, KanbanConfig } from '../../domain/ports/configProvider';
+import { DEFAULT_CONFIG } from '../../domain/ports/configProvider';
+import type { MarkdownTaskClient, ParseResult } from '../clients/markdownTaskClient';
+import type { VscodeDocumentClient } from '../clients/vscodeDocumentClient';
+import { DocumentNotFoundError } from '../clients/vscodeDocumentClient';
+import { FrontmatterConfigProvider } from './frontmatterConfigProvider';
+
+const createMockMarkdownClient = (config?: ParseResult['config']): MarkdownTaskClient =>
+	({
+		parse: vi.fn().mockReturnValue(
+			ok({
+				tasks: [],
+				headings: [],
+				warnings: [],
+				config,
+			} satisfies ParseResult),
+		),
+	}) as unknown as MarkdownTaskClient;
+
+const createMockDocumentClient = (text?: string): VscodeDocumentClient =>
+	({
+		getActiveDocumentText: vi
+			.fn()
+			.mockReturnValue(text !== undefined ? ok(text) : err(new DocumentNotFoundError())),
+	}) as unknown as VscodeDocumentClient;
+
+const createMockFallbackProvider = (config: KanbanConfig): ConfigProvider => ({
+	getConfig: vi.fn().mockResolvedValue(config),
+	get: vi.fn().mockImplementation(async <K extends keyof KanbanConfig>(key: K) => config[key]),
+});
+
+describe('FrontmatterConfigProvider', () => {
+	describe('getConfig', () => {
+		it('フロントマターから設定を取得する', async () => {
+			const markdownClient = createMockMarkdownClient({
+				statuses: ['backlog', 'doing', 'done'],
+				doneStatuses: ['done'],
+				defaultStatus: 'backlog',
+				defaultDoneStatus: 'done',
+				sortBy: 'priority',
+				syncCheckboxWithDone: false,
+			});
+			const documentClient = createMockDocumentClient(
+				'---\nkanban:\n  statuses: [backlog, doing, done]\n---',
+			);
+			const provider = new FrontmatterConfigProvider(markdownClient, documentClient);
+
+			const result = await provider.getConfig();
+
+			expect(result.statuses).toEqual(['backlog', 'doing', 'done']);
+			expect(result.sortBy).toBe('priority');
+			expect(result.syncCheckboxWithDone).toBe(false);
+		});
+
+		it('フロントマターがない場合はデフォルト設定を使用する', async () => {
+			const markdownClient = createMockMarkdownClient(undefined);
+			const documentClient = createMockDocumentClient('# No frontmatter');
+			const provider = new FrontmatterConfigProvider(markdownClient, documentClient);
+
+			const result = await provider.getConfig();
+
+			expect(result).toEqual(DEFAULT_CONFIG);
+		});
+
+		it('フロントマターの一部のみ設定されている場合はデフォルトにフォールバック', async () => {
+			const markdownClient = createMockMarkdownClient({
+				statuses: ['custom1', 'custom2'],
+			});
+			const documentClient = createMockDocumentClient(
+				'---\nkanban:\n  statuses: [custom1, custom2]\n---',
+			);
+			const provider = new FrontmatterConfigProvider(markdownClient, documentClient);
+
+			const result = await provider.getConfig();
+
+			expect(result.statuses).toEqual(['custom1', 'custom2']);
+			expect(result.doneStatuses).toEqual(DEFAULT_CONFIG.doneStatuses);
+			expect(result.defaultStatus).toBe(DEFAULT_CONFIG.defaultStatus);
+		});
+
+		it('フォールバックプロバイダが設定されている場合はそれを使用する', async () => {
+			const markdownClient = createMockMarkdownClient({
+				statuses: ['from-frontmatter'],
+			});
+			const documentClient = createMockDocumentClient(
+				'---\nkanban:\n  statuses: [from-frontmatter]\n---',
+			);
+			const fallbackConfig: KanbanConfig = {
+				...DEFAULT_CONFIG,
+				doneStatuses: ['completed'],
+				defaultStatus: 'new',
+			};
+			const fallbackProvider = createMockFallbackProvider(fallbackConfig);
+			const provider = new FrontmatterConfigProvider(
+				markdownClient,
+				documentClient,
+				fallbackProvider,
+			);
+
+			const result = await provider.getConfig();
+
+			expect(result.statuses).toEqual(['from-frontmatter']);
+			expect(result.doneStatuses).toEqual(['completed']);
+			expect(result.defaultStatus).toBe('new');
+		});
+
+		it('ドキュメントがない場合はフォールバック設定を使用する', async () => {
+			const markdownClient = createMockMarkdownClient();
+			const documentClient = createMockDocumentClient(); // エラーを返す
+			const fallbackConfig: KanbanConfig = {
+				...DEFAULT_CONFIG,
+				statuses: ['fallback-status'],
+			};
+			const fallbackProvider = createMockFallbackProvider(fallbackConfig);
+			const provider = new FrontmatterConfigProvider(
+				markdownClient,
+				documentClient,
+				fallbackProvider,
+			);
+
+			const result = await provider.getConfig();
+
+			expect(result.statuses).toEqual(['fallback-status']);
+		});
+
+		it('無効なsortBy値はフォールバック値を使用する', async () => {
+			const markdownClient = createMockMarkdownClient({
+				sortBy: 'invalid-sort',
+			});
+			const documentClient = createMockDocumentClient('---\nkanban:\n  sortBy: invalid\n---');
+			const provider = new FrontmatterConfigProvider(markdownClient, documentClient);
+
+			const result = await provider.getConfig();
+
+			expect(result.sortBy).toBe(DEFAULT_CONFIG.sortBy);
+		});
+	});
+
+	describe('get', () => {
+		it('特定の設定項目を取得する', async () => {
+			const markdownClient = createMockMarkdownClient({
+				statuses: ['custom'],
+			});
+			const documentClient = createMockDocumentClient('---\nkanban:\n  statuses: [custom]\n---');
+			const provider = new FrontmatterConfigProvider(markdownClient, documentClient);
+
+			const result = await provider.get('statuses');
+
+			expect(result).toEqual(['custom']);
+		});
+	});
+});

--- a/src/infrastructure/adapters/frontmatterConfigProvider.ts
+++ b/src/infrastructure/adapters/frontmatterConfigProvider.ts
@@ -1,0 +1,110 @@
+import {
+	type ConfigProvider,
+	DEFAULT_CONFIG,
+	type KanbanConfig,
+} from '../../domain/ports/configProvider';
+import type { FrontmatterConfig, MarkdownTaskClient } from '../clients/markdownTaskClient';
+import type { VscodeDocumentClient } from '../clients/vscodeDocumentClient';
+
+/**
+ * FrontmatterConfigProvider
+ * ConfigProviderポートのフロントマター実装
+ * フロントマター → フォールバックプロバイダ → デフォルト の優先順位で設定を解決
+ */
+export class FrontmatterConfigProvider implements ConfigProvider {
+	constructor(
+		private readonly markdownClient: MarkdownTaskClient,
+		private readonly documentClient: VscodeDocumentClient,
+		private readonly fallbackProvider?: ConfigProvider,
+	) {}
+
+	/**
+	 * 設定を取得する
+	 */
+	async getConfig(): Promise<KanbanConfig> {
+		const frontmatterConfig = this.getFrontmatterConfig();
+		const fallbackConfig = await this.getFallbackConfig();
+
+		return {
+			statuses: this.resolveArray(frontmatterConfig?.statuses, fallbackConfig.statuses),
+			doneStatuses: this.resolveArray(frontmatterConfig?.doneStatuses, fallbackConfig.doneStatuses),
+			defaultStatus: this.resolveString(
+				frontmatterConfig?.defaultStatus,
+				fallbackConfig.defaultStatus,
+			),
+			defaultDoneStatus: this.resolveString(
+				frontmatterConfig?.defaultDoneStatus,
+				fallbackConfig.defaultDoneStatus,
+			),
+			sortBy: this.resolveSortBy(frontmatterConfig?.sortBy, fallbackConfig.sortBy),
+			syncCheckboxWithDone: this.resolveBoolean(
+				frontmatterConfig?.syncCheckboxWithDone,
+				fallbackConfig.syncCheckboxWithDone,
+			),
+		};
+	}
+
+	/**
+	 * 特定の設定項目を取得する
+	 */
+	async get<K extends keyof KanbanConfig>(key: K): Promise<KanbanConfig[K]> {
+		const config = await this.getConfig();
+		return config[key];
+	}
+
+	private getFrontmatterConfig(): FrontmatterConfig | undefined {
+		const textResult = this.documentClient.getActiveDocumentText();
+		if (textResult.isErr()) {
+			return undefined;
+		}
+
+		const parseResult = this.markdownClient.parse(textResult.value);
+		if (parseResult.isErr()) {
+			return undefined;
+		}
+
+		return parseResult.value.config;
+	}
+
+	private async getFallbackConfig(): Promise<KanbanConfig> {
+		if (this.fallbackProvider) {
+			return this.fallbackProvider.getConfig();
+		}
+		return DEFAULT_CONFIG;
+	}
+
+	private resolveArray(frontmatterValue: string[] | undefined, fallbackValue: string[]): string[] {
+		if (Array.isArray(frontmatterValue) && frontmatterValue.length > 0) {
+			return frontmatterValue;
+		}
+		return fallbackValue;
+	}
+
+	private resolveString(frontmatterValue: string | undefined, fallbackValue: string): string {
+		if (typeof frontmatterValue === 'string' && frontmatterValue.trim() !== '') {
+			return frontmatterValue;
+		}
+		return fallbackValue;
+	}
+
+	private resolveBoolean(frontmatterValue: boolean | undefined, fallbackValue: boolean): boolean {
+		if (typeof frontmatterValue === 'boolean') {
+			return frontmatterValue;
+		}
+		return fallbackValue;
+	}
+
+	private resolveSortBy(
+		frontmatterValue: string | undefined,
+		fallbackValue: KanbanConfig['sortBy'],
+	): KanbanConfig['sortBy'] {
+		const validValues: KanbanConfig['sortBy'][] = ['markdown', 'priority', 'due', 'alphabetical'];
+		if (
+			typeof frontmatterValue === 'string' &&
+			validValues.includes(frontmatterValue as KanbanConfig['sortBy'])
+		) {
+			return frontmatterValue as KanbanConfig['sortBy'];
+		}
+		return fallbackValue;
+	}
+}

--- a/src/infrastructure/adapters/index.ts
+++ b/src/infrastructure/adapters/index.ts
@@ -1,3 +1,4 @@
 // Infrastructure Adapters
-// 現在はアダプターはありません。将来、MarkdownTaskRepositoryなどが追加される予定です。
-export {};
+export { FrontmatterConfigProvider } from './frontmatterConfigProvider';
+export { MarkdownTaskRepository } from './markdownTaskRepository';
+export { VscodeConfigProvider } from './vscodeConfigProvider';

--- a/src/infrastructure/adapters/markdownTaskRepository.test.ts
+++ b/src/infrastructure/adapters/markdownTaskRepository.test.ts
@@ -1,0 +1,377 @@
+import { ok } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { Task } from '../../domain/entities/task';
+import { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
+import { TaskParseError } from '../../domain/errors/taskParseError';
+import { Path } from '../../domain/valueObjects/path';
+import { Status } from '../../domain/valueObjects/status';
+import type { MarkdownTaskClient, ParseResult } from '../clients/markdownTaskClient';
+import type { VscodeDocumentClient } from '../clients/vscodeDocumentClient';
+import { MarkdownTaskRepository } from './markdownTaskRepository';
+
+// テスト用ヘルパー: 確実に成功するステータスを作成
+const createStatus = (value: string): Status => {
+	const result = Status.create(value);
+	if (result.isErr()) {
+		throw new Error(`Invalid status: ${value}`);
+	}
+	return result.value;
+};
+
+const createMockMarkdownTaskClient = (
+	overrides: Partial<MarkdownTaskClient> = {},
+): MarkdownTaskClient =>
+	({
+		parse: vi.fn().mockReturnValue(
+			ok({
+				tasks: [],
+				headings: [],
+				warnings: [],
+			} satisfies ParseResult),
+		),
+		applyEdit: vi.fn().mockReturnValue(ok('# Test')),
+		...overrides,
+	}) as unknown as MarkdownTaskClient;
+
+const createMockVscodeDocumentClient = (
+	overrides: Partial<VscodeDocumentClient> = {},
+): VscodeDocumentClient =>
+	({
+		getActiveDocumentText: vi.fn().mockReturnValue(ok('# Test')),
+		replaceDocumentText: vi.fn().mockResolvedValue(ok(undefined)),
+		...overrides,
+	}) as unknown as VscodeDocumentClient;
+
+const createMockTask = (overrides: Partial<Parameters<typeof Task.create>[0]> = {}): Task =>
+	Task.create({
+		id: 'Test::Task 1',
+		title: 'Task 1',
+		status: createStatus('todo'),
+		path: Path.create(['Test']),
+		isChecked: false,
+		metadata: {},
+		...overrides,
+	});
+
+describe('MarkdownTaskRepository', () => {
+	describe('findAll', () => {
+		it('全てのタスクを取得する', async () => {
+			const parsedTasks = [
+				{
+					id: 'Test::Task 1',
+					title: 'Task 1',
+					status: createStatus('todo'),
+					path: Path.create(['Test']),
+					isChecked: false,
+					metadata: {},
+					startLine: 2,
+					endLine: 3,
+				},
+				{
+					id: 'Test::Task 2',
+					title: 'Task 2',
+					status: createStatus('done'),
+					path: Path.create(['Test']),
+					isChecked: true,
+					metadata: {},
+					startLine: 4,
+					endLine: 5,
+				},
+			];
+
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: parsedTasks,
+						headings: [],
+						warnings: [],
+					}),
+				),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.findAll();
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value).toHaveLength(2);
+				expect(result.value[0].title).toBe('Task 1');
+				expect(result.value[1].title).toBe('Task 2');
+			}
+		});
+
+		it('ドキュメントがない場合はエラーを返す', async () => {
+			const markdownClient = createMockMarkdownTaskClient();
+			const documentClient = createMockVscodeDocumentClient({
+				getActiveDocumentText: vi.fn().mockReturnValue({
+					isErr: () => true,
+					isOk: () => false,
+					error: { message: 'No document' },
+				}),
+			});
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.findAll();
+
+			expect(result.isErr()).toBe(true);
+			if (result.isErr()) {
+				expect(result.error).toBeInstanceOf(TaskParseError);
+			}
+		});
+	});
+
+	describe('findById', () => {
+		it('IDでタスクを取得する', async () => {
+			const parsedTasks = [
+				{
+					id: 'Test::Task 1',
+					title: 'Task 1',
+					status: createStatus('todo'),
+					path: Path.create(['Test']),
+					isChecked: false,
+					metadata: {},
+					startLine: 2,
+					endLine: 3,
+				},
+			];
+
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: parsedTasks,
+						headings: [],
+						warnings: [],
+					}),
+				),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.findById('Test::Task 1');
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value.title).toBe('Task 1');
+			}
+		});
+
+		it('タスクが見つからない場合はエラーを返す', async () => {
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: [],
+						headings: [],
+						warnings: [],
+					}),
+				),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.findById('nonexistent');
+
+			expect(result.isErr()).toBe(true);
+			if (result.isErr()) {
+				expect(result.error).toBeInstanceOf(TaskNotFoundError);
+			}
+		});
+	});
+
+	describe('findByPath', () => {
+		it('パスでタスクをフィルタリングする', async () => {
+			const parsedTasks = [
+				{
+					id: 'Test::Task 1',
+					title: 'Task 1',
+					status: createStatus('todo'),
+					path: Path.create(['Test']),
+					isChecked: false,
+					metadata: {},
+					startLine: 2,
+					endLine: 3,
+				},
+				{
+					id: 'Other::Task 2',
+					title: 'Task 2',
+					status: createStatus('todo'),
+					path: Path.create(['Other']),
+					isChecked: false,
+					metadata: {},
+					startLine: 4,
+					endLine: 5,
+				},
+			];
+
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: parsedTasks,
+						headings: [],
+						warnings: [],
+					}),
+				),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.findByPath(Path.create(['Test']));
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value).toHaveLength(1);
+				expect(result.value[0].title).toBe('Task 1');
+			}
+		});
+	});
+
+	describe('save', () => {
+		it('新しいタスクを作成する', async () => {
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: [],
+						headings: [Path.create(['Test'])],
+						warnings: [],
+					}),
+				),
+				applyEdit: vi.fn().mockReturnValue(ok('# Test\n- [ ] New Task\n  - status: todo')),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const newTask = createMockTask({ id: 'Test::New Task', title: 'New Task' });
+			const result = await repository.save(newTask);
+
+			expect(result.isOk()).toBe(true);
+			expect(markdownClient.applyEdit).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ create: expect.any(Object) }),
+			);
+		});
+
+		it('既存のタスクを更新する', async () => {
+			const existingTask = {
+				id: 'Test::Task 1',
+				title: 'Task 1',
+				status: createStatus('todo'),
+				path: Path.create(['Test']),
+				isChecked: false,
+				metadata: {},
+				startLine: 2,
+				endLine: 3,
+			};
+
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: [existingTask],
+						headings: [],
+						warnings: [],
+					}),
+				),
+				applyEdit: vi.fn().mockReturnValue(ok('# Test\n- [x] Task 1\n  - status: done')),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const updatedTask = createMockTask({
+				id: 'Test::Task 1',
+				title: 'Task 1',
+				status: createStatus('done'),
+				isChecked: true,
+			});
+			const result = await repository.save(updatedTask);
+
+			expect(result.isOk()).toBe(true);
+			expect(markdownClient.applyEdit).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ taskId: 'Test::Task 1' }),
+			);
+		});
+	});
+
+	describe('delete', () => {
+		it('タスクを削除する', async () => {
+			const existingTask = {
+				id: 'Test::Task 1',
+				title: 'Task 1',
+				status: createStatus('todo'),
+				path: Path.create(['Test']),
+				isChecked: false,
+				metadata: {},
+				startLine: 2,
+				endLine: 3,
+			};
+
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: [existingTask],
+						headings: [],
+						warnings: [],
+					}),
+				),
+				applyEdit: vi.fn().mockReturnValue(ok('# Test')),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.delete('Test::Task 1');
+
+			expect(result.isOk()).toBe(true);
+			expect(markdownClient.applyEdit).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ taskId: 'Test::Task 1', delete: true }),
+			);
+		});
+
+		it('タスクが見つからない場合はエラーを返す', async () => {
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: [],
+						headings: [],
+						warnings: [],
+					}),
+				),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.delete('nonexistent');
+
+			expect(result.isErr()).toBe(true);
+			if (result.isErr()) {
+				expect(result.error).toBeInstanceOf(TaskNotFoundError);
+			}
+		});
+	});
+
+	describe('getAvailablePaths', () => {
+		it('利用可能なパスを取得する', async () => {
+			const headings = [Path.create(['Section 1']), Path.create(['Section 1', 'Subsection'])];
+
+			const markdownClient = createMockMarkdownTaskClient({
+				parse: vi.fn().mockReturnValue(
+					ok({
+						tasks: [],
+						headings,
+						warnings: [],
+					}),
+				),
+			});
+			const documentClient = createMockVscodeDocumentClient();
+
+			const repository = new MarkdownTaskRepository(markdownClient, documentClient);
+			const result = await repository.getAvailablePaths();
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value).toHaveLength(2);
+				expect(result.value[0].toString()).toBe('Section 1');
+				expect(result.value[1].toString()).toBe('Section 1 / Subsection');
+			}
+		});
+	});
+});

--- a/src/infrastructure/adapters/markdownTaskRepository.ts
+++ b/src/infrastructure/adapters/markdownTaskRepository.ts
@@ -1,0 +1,184 @@
+import { err, ok, type Result } from 'neverthrow';
+import { Task } from '../../domain/entities/task';
+import { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
+import { TaskParseError } from '../../domain/errors/taskParseError';
+import type { TaskRepository } from '../../domain/ports/taskRepository';
+import type { Path } from '../../domain/valueObjects/path';
+import type { MarkdownTaskClient, ParsedTask } from '../clients/markdownTaskClient';
+import type { VscodeDocumentClient } from '../clients/vscodeDocumentClient';
+
+/**
+ * MarkdownTaskRepository
+ * TaskRepositoryポートのMarkdown実装
+ */
+export class MarkdownTaskRepository implements TaskRepository {
+	constructor(
+		private readonly markdownClient: MarkdownTaskClient,
+		private readonly documentClient: VscodeDocumentClient,
+	) {}
+
+	/**
+	 * 全タスクを取得する
+	 */
+	async findAll(): Promise<Result<Task[], TaskParseError>> {
+		const textResult = this.documentClient.getActiveDocumentText();
+		if (textResult.isErr()) {
+			return err(new TaskParseError(0, textResult.error.message));
+		}
+
+		const parseResult = this.markdownClient.parse(textResult.value);
+		if (parseResult.isErr()) {
+			return err(new TaskParseError(0, parseResult.error.message));
+		}
+
+		const tasks = parseResult.value.tasks.map((parsedTask) => this.toTask(parsedTask));
+		return ok(tasks);
+	}
+
+	/**
+	 * IDでタスクを取得する
+	 */
+	async findById(id: string): Promise<Result<Task, TaskNotFoundError | TaskParseError>> {
+		const allResult = await this.findAll();
+		if (allResult.isErr()) {
+			return err(allResult.error);
+		}
+
+		const task = allResult.value.find((t) => t.id === id);
+		if (!task) {
+			return err(new TaskNotFoundError(id));
+		}
+
+		return ok(task);
+	}
+
+	/**
+	 * パスでタスクをフィルタリングして取得する
+	 */
+	async findByPath(path: Path): Promise<Result<Task[], TaskParseError>> {
+		const allResult = await this.findAll();
+		if (allResult.isErr()) {
+			return err(allResult.error);
+		}
+
+		const tasks = allResult.value.filter((t) => t.path.equals(path));
+		return ok(tasks);
+	}
+
+	/**
+	 * タスクを保存する（作成または更新）
+	 */
+	async save(task: Task): Promise<Result<Task, TaskNotFoundError>> {
+		const textResult = this.documentClient.getActiveDocumentText();
+		if (textResult.isErr()) {
+			return err(new TaskNotFoundError(task.id));
+		}
+
+		const markdown = textResult.value;
+		const parseResult = this.markdownClient.parse(markdown);
+		if (parseResult.isErr()) {
+			return err(new TaskNotFoundError(task.id));
+		}
+
+		const existingTask = parseResult.value.tasks.find((t) => t.id === task.id);
+
+		let editResult: ReturnType<MarkdownTaskClient['applyEdit']>;
+
+		if (existingTask) {
+			// 更新
+			editResult = this.markdownClient.applyEdit(markdown, {
+				taskId: task.id,
+				newStatus: task.status,
+				newTitle: task.title !== existingTask.title ? task.title : undefined,
+			});
+		} else {
+			// 作成
+			editResult = this.markdownClient.applyEdit(markdown, {
+				create: {
+					title: task.title,
+					path: task.path,
+					status: task.status,
+				},
+			});
+		}
+
+		if (editResult.isErr()) {
+			return err(new TaskNotFoundError(task.id));
+		}
+
+		const writeResult = await this.documentClient.replaceDocumentText(editResult.value);
+		if (writeResult.isErr()) {
+			return err(new TaskNotFoundError(task.id));
+		}
+
+		return ok(task);
+	}
+
+	/**
+	 * タスクを削除する
+	 */
+	async delete(id: string): Promise<Result<void, TaskNotFoundError>> {
+		const textResult = this.documentClient.getActiveDocumentText();
+		if (textResult.isErr()) {
+			return err(new TaskNotFoundError(id));
+		}
+
+		const markdown = textResult.value;
+		const parseResult = this.markdownClient.parse(markdown);
+		if (parseResult.isErr()) {
+			return err(new TaskNotFoundError(id));
+		}
+
+		const existingTask = parseResult.value.tasks.find((t) => t.id === id);
+		if (!existingTask) {
+			return err(new TaskNotFoundError(id));
+		}
+
+		const editResult = this.markdownClient.applyEdit(markdown, {
+			taskId: id,
+			delete: true,
+		});
+
+		if (editResult.isErr()) {
+			return err(new TaskNotFoundError(id));
+		}
+
+		const writeResult = await this.documentClient.replaceDocumentText(editResult.value);
+		if (writeResult.isErr()) {
+			return err(new TaskNotFoundError(id));
+		}
+
+		return ok(undefined);
+	}
+
+	/**
+	 * 利用可能なパス（見出し階層）を全て取得する
+	 */
+	async getAvailablePaths(): Promise<Result<Path[], TaskParseError>> {
+		const textResult = this.documentClient.getActiveDocumentText();
+		if (textResult.isErr()) {
+			return err(new TaskParseError(0, textResult.error.message));
+		}
+
+		const parseResult = this.markdownClient.parse(textResult.value);
+		if (parseResult.isErr()) {
+			return err(new TaskParseError(0, parseResult.error.message));
+		}
+
+		return ok(parseResult.value.headings);
+	}
+
+	/**
+	 * ParsedTaskをTaskエンティティに変換
+	 */
+	private toTask(parsedTask: ParsedTask): Task {
+		return Task.create({
+			id: parsedTask.id,
+			title: parsedTask.title,
+			status: parsedTask.status,
+			path: parsedTask.path,
+			isChecked: parsedTask.isChecked,
+			metadata: parsedTask.metadata,
+		});
+	}
+}

--- a/src/infrastructure/adapters/vscodeConfigProvider.test.ts
+++ b/src/infrastructure/adapters/vscodeConfigProvider.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CONFIG } from '../../domain/ports/configProvider';
+import type { VscodeConfigClient } from '../clients/vscodeConfigClient';
+import { VscodeConfigProvider } from './vscodeConfigProvider';
+
+const createMockConfigClient = (allSettings: Record<string, unknown> = {}): VscodeConfigClient =>
+	({
+		getAll: vi.fn().mockReturnValue(allSettings),
+		get: vi.fn().mockImplementation((key: string) => allSettings[key]),
+		getWithDefault: vi
+			.fn()
+			.mockImplementation((key: string, defaultValue: unknown) =>
+				key in allSettings ? allSettings[key] : defaultValue,
+			),
+	}) as unknown as VscodeConfigClient;
+
+describe('VscodeConfigProvider', () => {
+	describe('getConfig', () => {
+		it('VSCode設定から値を取得する', async () => {
+			const configClient = createMockConfigClient({
+				statuses: ['backlog', 'wip', 'done'],
+				doneStatuses: ['done'],
+				defaultStatus: 'backlog',
+				defaultDoneStatus: 'done',
+				sortBy: 'priority',
+				syncCheckboxWithDone: false,
+			});
+			const provider = new VscodeConfigProvider(configClient);
+
+			const result = await provider.getConfig();
+
+			expect(result).toEqual({
+				statuses: ['backlog', 'wip', 'done'],
+				doneStatuses: ['done'],
+				defaultStatus: 'backlog',
+				defaultDoneStatus: 'done',
+				sortBy: 'priority',
+				syncCheckboxWithDone: false,
+			});
+		});
+
+		it('設定が未定義の場合はデフォルト値を使用する', async () => {
+			const configClient = createMockConfigClient({});
+			const provider = new VscodeConfigProvider(configClient);
+
+			const result = await provider.getConfig();
+
+			expect(result).toEqual(DEFAULT_CONFIG);
+		});
+
+		it('一部の設定のみカスタマイズされている場合', async () => {
+			const configClient = createMockConfigClient({
+				statuses: ['custom-todo', 'custom-done'],
+			});
+			const provider = new VscodeConfigProvider(configClient);
+
+			const result = await provider.getConfig();
+
+			expect(result.statuses).toEqual(['custom-todo', 'custom-done']);
+			expect(result.doneStatuses).toEqual(DEFAULT_CONFIG.doneStatuses);
+			expect(result.defaultStatus).toBe(DEFAULT_CONFIG.defaultStatus);
+		});
+
+		it('無効なsortBy値はデフォルトにフォールバック', async () => {
+			const configClient = createMockConfigClient({
+				sortBy: 'invalid-sort',
+			});
+			const provider = new VscodeConfigProvider(configClient);
+
+			const result = await provider.getConfig();
+
+			expect(result.sortBy).toBe(DEFAULT_CONFIG.sortBy);
+		});
+
+		it('空文字列はデフォルト値にフォールバック', async () => {
+			const configClient = createMockConfigClient({
+				defaultStatus: '',
+			});
+			const provider = new VscodeConfigProvider(configClient);
+
+			const result = await provider.getConfig();
+
+			expect(result.defaultStatus).toBe(DEFAULT_CONFIG.defaultStatus);
+		});
+	});
+
+	describe('get', () => {
+		it('特定の設定項目を取得する', async () => {
+			const configClient = createMockConfigClient({
+				statuses: ['custom'],
+			});
+			const provider = new VscodeConfigProvider(configClient);
+
+			const result = await provider.get('statuses');
+
+			expect(result).toEqual(['custom']);
+		});
+	});
+});

--- a/src/infrastructure/adapters/vscodeConfigProvider.ts
+++ b/src/infrastructure/adapters/vscodeConfigProvider.ts
@@ -1,0 +1,73 @@
+import {
+	type ConfigProvider,
+	DEFAULT_CONFIG,
+	type KanbanConfig,
+} from '../../domain/ports/configProvider';
+import type { VscodeConfigClient } from '../clients/vscodeConfigClient';
+
+/**
+ * VscodeConfigProvider
+ * ConfigProviderポートのVSCode設定実装
+ */
+export class VscodeConfigProvider implements ConfigProvider {
+	constructor(private readonly configClient: VscodeConfigClient) {}
+
+	/**
+	 * 設定を取得する
+	 */
+	async getConfig(): Promise<KanbanConfig> {
+		const allSettings = this.configClient.getAll();
+
+		return {
+			statuses: this.resolveArray(allSettings.statuses, DEFAULT_CONFIG.statuses),
+			doneStatuses: this.resolveArray(allSettings.doneStatuses, DEFAULT_CONFIG.doneStatuses),
+			defaultStatus: this.resolveString(allSettings.defaultStatus, DEFAULT_CONFIG.defaultStatus),
+			defaultDoneStatus: this.resolveString(
+				allSettings.defaultDoneStatus,
+				DEFAULT_CONFIG.defaultDoneStatus,
+			),
+			sortBy: this.resolveSortBy(allSettings.sortBy),
+			syncCheckboxWithDone: this.resolveBoolean(
+				allSettings.syncCheckboxWithDone,
+				DEFAULT_CONFIG.syncCheckboxWithDone,
+			),
+		};
+	}
+
+	/**
+	 * 特定の設定項目を取得する
+	 */
+	async get<K extends keyof KanbanConfig>(key: K): Promise<KanbanConfig[K]> {
+		const config = await this.getConfig();
+		return config[key];
+	}
+
+	private resolveArray(value: unknown, defaultValue: string[]): string[] {
+		if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+			return value;
+		}
+		return defaultValue;
+	}
+
+	private resolveString(value: unknown, defaultValue: string): string {
+		if (typeof value === 'string' && value.trim() !== '') {
+			return value;
+		}
+		return defaultValue;
+	}
+
+	private resolveBoolean(value: unknown, defaultValue: boolean): boolean {
+		if (typeof value === 'boolean') {
+			return value;
+		}
+		return defaultValue;
+	}
+
+	private resolveSortBy(value: unknown): KanbanConfig['sortBy'] {
+		const validValues: KanbanConfig['sortBy'][] = ['markdown', 'priority', 'due', 'alphabetical'];
+		if (typeof value === 'string' && validValues.includes(value as KanbanConfig['sortBy'])) {
+			return value as KanbanConfig['sortBy'];
+		}
+		return DEFAULT_CONFIG.sortBy;
+	}
+}

--- a/src/infrastructure/clients/index.ts
+++ b/src/infrastructure/clients/index.ts
@@ -11,3 +11,11 @@ export {
 	type TaskEdit,
 } from './markdownTaskClient';
 export { type FrontmatterResult, RemarkClient } from './remarkClient';
+export { VscodeConfigClient, type VscodeConfigDeps } from './vscodeConfigClient';
+export {
+	DocumentEditError,
+	type DocumentInfo,
+	DocumentNotFoundError,
+	VscodeDocumentClient,
+	type VscodeDocumentDeps,
+} from './vscodeDocumentClient';

--- a/src/infrastructure/clients/vscodeConfigClient.test.ts
+++ b/src/infrastructure/clients/vscodeConfigClient.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { VscodeConfigClient, type VscodeConfigDeps } from './vscodeConfigClient';
+
+const createMockDeps = (configValues: Record<string, unknown> = {}): VscodeConfigDeps => ({
+	getConfiguration: vi.fn().mockReturnValue({
+		get: vi.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+			return key in configValues ? configValues[key] : defaultValue;
+		}),
+	}),
+});
+
+describe('VscodeConfigClient', () => {
+	describe('get', () => {
+		it('設定値を取得する', () => {
+			const deps = createMockDeps({
+				statuses: ['todo', 'in-progress', 'done'],
+			});
+			const client = new VscodeConfigClient(deps);
+
+			const result = client.get<string[]>('statuses');
+
+			expect(result).toEqual(['todo', 'in-progress', 'done']);
+		});
+
+		it('設定値が存在しない場合はundefinedを返す', () => {
+			const deps = createMockDeps({});
+			const client = new VscodeConfigClient(deps);
+
+			const result = client.get<string[]>('nonexistent');
+
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('getWithDefault', () => {
+		it('設定値を取得する', () => {
+			const deps = createMockDeps({
+				statuses: ['custom-status'],
+			});
+			const client = new VscodeConfigClient(deps);
+
+			const result = client.getWithDefault('statuses', ['todo']);
+
+			expect(result).toEqual(['custom-status']);
+		});
+
+		it('設定値が存在しない場合はデフォルト値を返す', () => {
+			const deps = createMockDeps({});
+			const client = new VscodeConfigClient(deps);
+
+			const result = client.getWithDefault('statuses', ['default']);
+
+			expect(result).toEqual(['default']);
+		});
+	});
+
+	describe('getAll', () => {
+		it('全ての設定を取得する', () => {
+			const deps = createMockDeps({
+				statuses: ['todo', 'done'],
+				doneStatuses: ['done'],
+				defaultStatus: 'todo',
+				defaultDoneStatus: 'done',
+				sortBy: 'markdown',
+				syncCheckboxWithDone: true,
+			});
+			const client = new VscodeConfigClient(deps);
+
+			const result = client.getAll();
+
+			expect(result).toEqual({
+				statuses: ['todo', 'done'],
+				doneStatuses: ['done'],
+				defaultStatus: 'todo',
+				defaultDoneStatus: 'done',
+				sortBy: 'markdown',
+				syncCheckboxWithDone: true,
+			});
+		});
+
+		it('未設定の項目はundefinedになる', () => {
+			const deps = createMockDeps({
+				statuses: ['todo'],
+			});
+			const client = new VscodeConfigClient(deps);
+
+			const result = client.getAll();
+
+			expect(result.statuses).toEqual(['todo']);
+			expect(result.doneStatuses).toBeUndefined();
+		});
+	});
+});

--- a/src/infrastructure/clients/vscodeConfigClient.ts
+++ b/src/infrastructure/clients/vscodeConfigClient.ts
@@ -1,0 +1,50 @@
+import type * as vscode from 'vscode';
+
+/**
+ * VSCode設定取得の依存性インターフェース
+ * テスト時にモック可能にするため
+ */
+export interface VscodeConfigDeps {
+	getConfiguration(section?: string): vscode.WorkspaceConfiguration;
+}
+
+/**
+ * VscodeConfigClient
+ * VSCode設定APIのラッパー
+ */
+export class VscodeConfigClient {
+	private static readonly CONFIG_SECTION = 'markdownKanban';
+
+	constructor(private readonly deps: VscodeConfigDeps) {}
+
+	/**
+	 * 設定値を取得する
+	 */
+	get<T>(key: string): T | undefined {
+		const config = this.deps.getConfiguration(VscodeConfigClient.CONFIG_SECTION);
+		return config.get<T>(key);
+	}
+
+	/**
+	 * 設定値を取得する（デフォルト値付き）
+	 */
+	getWithDefault<T>(key: string, defaultValue: T): T {
+		const config = this.deps.getConfiguration(VscodeConfigClient.CONFIG_SECTION);
+		return config.get<T>(key, defaultValue);
+	}
+
+	/**
+	 * 全設定を取得する
+	 */
+	getAll(): Record<string, unknown> {
+		const config = this.deps.getConfiguration(VscodeConfigClient.CONFIG_SECTION);
+		return {
+			statuses: config.get('statuses'),
+			doneStatuses: config.get('doneStatuses'),
+			defaultStatus: config.get('defaultStatus'),
+			defaultDoneStatus: config.get('defaultDoneStatus'),
+			sortBy: config.get('sortBy'),
+			syncCheckboxWithDone: config.get('syncCheckboxWithDone'),
+		};
+	}
+}

--- a/src/infrastructure/clients/vscodeDocumentClient.test.ts
+++ b/src/infrastructure/clients/vscodeDocumentClient.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import {
+	DocumentEditError,
+	DocumentNotFoundError,
+	VscodeDocumentClient,
+	type VscodeDocumentDeps,
+} from './vscodeDocumentClient';
+
+const createMockUri = (path: string): vscode.Uri =>
+	({
+		scheme: 'file',
+		path,
+		fsPath: path,
+	}) as vscode.Uri;
+
+const createMockRange = (
+	startLine: number,
+	startCharacter: number,
+	endLine: number,
+	endCharacter: number,
+): vscode.Range =>
+	({
+		start: { line: startLine, character: startCharacter },
+		end: { line: endLine, character: endCharacter },
+	}) as vscode.Range;
+
+const createMockDeps = (overrides: Partial<VscodeDocumentDeps> = {}): VscodeDocumentDeps => ({
+	getActiveTextEditor: vi.fn().mockReturnValue(undefined),
+	openTextDocument: vi.fn().mockResolvedValue({ getText: () => '' }),
+	applyEdit: vi.fn().mockResolvedValue(true),
+	createWorkspaceEdit: vi.fn().mockReturnValue({ replace: vi.fn() }),
+	createRange: vi.fn().mockImplementation(createMockRange),
+	...overrides,
+});
+
+describe('VscodeDocumentClient', () => {
+	describe('getActiveDocument', () => {
+		it('アクティブなエディタがない場合はエラーを返す', () => {
+			const deps = createMockDeps({
+				getActiveTextEditor: vi.fn().mockReturnValue(undefined),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = client.getActiveDocument();
+
+			expect(result.isErr()).toBe(true);
+			if (result.isErr()) {
+				expect(result.error).toBeInstanceOf(DocumentNotFoundError);
+				expect(result.error.message).toBe('アクティブなエディタがありません');
+			}
+		});
+
+		it('アクティブなドキュメントの情報を返す', () => {
+			const mockUri = createMockUri('/test/file.md');
+			const mockDocument = {
+				uri: mockUri,
+				getText: () => '# Test\n- [ ] Task 1',
+				languageId: 'markdown',
+				lineCount: 2,
+			};
+			const mockEditor = { document: mockDocument };
+
+			const deps = createMockDeps({
+				getActiveTextEditor: vi.fn().mockReturnValue(mockEditor),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = client.getActiveDocument();
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value.uri).toBe(mockUri);
+				expect(result.value.text).toBe('# Test\n- [ ] Task 1');
+				expect(result.value.languageId).toBe('markdown');
+				expect(result.value.lineCount).toBe(2);
+			}
+		});
+	});
+
+	describe('getActiveDocumentText', () => {
+		it('アクティブなドキュメントのテキストを返す', () => {
+			const mockDocument = {
+				uri: createMockUri('/test/file.md'),
+				getText: () => '# Test Content',
+				languageId: 'markdown',
+				lineCount: 1,
+			};
+			const mockEditor = { document: mockDocument };
+
+			const deps = createMockDeps({
+				getActiveTextEditor: vi.fn().mockReturnValue(mockEditor),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = client.getActiveDocumentText();
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value).toBe('# Test Content');
+			}
+		});
+	});
+
+	describe('getActiveDocumentUri', () => {
+		it('アクティブなドキュメントのURIを返す', () => {
+			const mockUri = createMockUri('/test/file.md');
+			const mockDocument = {
+				uri: mockUri,
+				getText: () => '',
+				languageId: 'markdown',
+				lineCount: 0,
+			};
+			const mockEditor = { document: mockDocument };
+
+			const deps = createMockDeps({
+				getActiveTextEditor: vi.fn().mockReturnValue(mockEditor),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = client.getActiveDocumentUri();
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value).toBe(mockUri);
+			}
+		});
+	});
+
+	describe('replaceDocumentText', () => {
+		it('ドキュメントのテキストを置換する', async () => {
+			const mockUri = createMockUri('/test/file.md');
+			const originalText = '# Original\n- [ ] Task';
+			const newText = '# Updated\n- [x] Task';
+			const mockReplace = vi.fn();
+
+			const mockDocument = {
+				uri: mockUri,
+				getText: () => originalText,
+				languageId: 'markdown',
+				lineCount: 2,
+			};
+			const mockEditor = { document: mockDocument };
+
+			const deps = createMockDeps({
+				getActiveTextEditor: vi.fn().mockReturnValue(mockEditor),
+				createWorkspaceEdit: vi.fn().mockReturnValue({ replace: mockReplace }),
+				applyEdit: vi.fn().mockResolvedValue(true),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = await client.replaceDocumentText(newText);
+
+			expect(result.isOk()).toBe(true);
+			expect(mockReplace).toHaveBeenCalledWith(mockUri, expect.anything(), newText);
+			expect(deps.applyEdit).toHaveBeenCalled();
+		});
+
+		it('アクティブなエディタがない場合はエラーを返す', async () => {
+			const deps = createMockDeps({
+				getActiveTextEditor: vi.fn().mockReturnValue(undefined),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = await client.replaceDocumentText('new text');
+
+			expect(result.isErr()).toBe(true);
+			if (result.isErr()) {
+				expect(result.error).toBeInstanceOf(DocumentNotFoundError);
+			}
+		});
+
+		it('編集に失敗した場合はエラーを返す', async () => {
+			const mockDocument = {
+				uri: createMockUri('/test/file.md'),
+				getText: () => 'text',
+				languageId: 'markdown',
+				lineCount: 1,
+			};
+			const mockEditor = { document: mockDocument };
+
+			const deps = createMockDeps({
+				getActiveTextEditor: vi.fn().mockReturnValue(mockEditor),
+				applyEdit: vi.fn().mockResolvedValue(false),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = await client.replaceDocumentText('new text');
+
+			expect(result.isErr()).toBe(true);
+			if (result.isErr()) {
+				expect(result.error).toBeInstanceOf(DocumentEditError);
+			}
+		});
+	});
+
+	describe('openAndGetText', () => {
+		it('URIからドキュメントを開いてテキストを取得する', async () => {
+			const mockUri = createMockUri('/test/file.md');
+			const expectedText = '# File Content';
+
+			const deps = createMockDeps({
+				openTextDocument: vi.fn().mockResolvedValue({ getText: () => expectedText }),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = await client.openAndGetText(mockUri);
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value).toBe(expectedText);
+			}
+			expect(deps.openTextDocument).toHaveBeenCalledWith(mockUri);
+		});
+
+		it('ドキュメントを開けない場合はエラーを返す', async () => {
+			const mockUri = createMockUri('/test/nonexistent.md');
+
+			const deps = createMockDeps({
+				openTextDocument: vi.fn().mockRejectedValue(new Error('File not found')),
+			});
+			const client = new VscodeDocumentClient(deps);
+
+			const result = await client.openAndGetText(mockUri);
+
+			expect(result.isErr()).toBe(true);
+			if (result.isErr()) {
+				expect(result.error).toBeInstanceOf(DocumentNotFoundError);
+				expect(result.error.message).toContain('File not found');
+			}
+		});
+	});
+});

--- a/src/infrastructure/clients/vscodeDocumentClient.ts
+++ b/src/infrastructure/clients/vscodeDocumentClient.ts
@@ -1,0 +1,142 @@
+import { err, ok, type Result } from 'neverthrow';
+import type * as vscode from 'vscode';
+
+/**
+ * ドキュメントが見つからないエラー
+ */
+export class DocumentNotFoundError extends Error {
+	readonly _tag = 'DocumentNotFoundError';
+	constructor(message = 'ドキュメントが見つかりません') {
+		super(message);
+		this.name = 'DocumentNotFoundError';
+	}
+}
+
+/**
+ * ドキュメント編集エラー
+ */
+export class DocumentEditError extends Error {
+	readonly _tag = 'DocumentEditError';
+	constructor(message: string) {
+		super(message);
+		this.name = 'DocumentEditError';
+	}
+}
+
+/**
+ * VSCodeドキュメント操作の依存性インターフェース
+ * テスト時にモック可能にするため
+ */
+export interface VscodeDocumentDeps {
+	getActiveTextEditor(): vscode.TextEditor | undefined;
+	openTextDocument(uri: vscode.Uri): Thenable<vscode.TextDocument>;
+	applyEdit(edit: vscode.WorkspaceEdit): Thenable<boolean>;
+	createWorkspaceEdit(): vscode.WorkspaceEdit;
+	createRange(
+		startLine: number,
+		startCharacter: number,
+		endLine: number,
+		endCharacter: number,
+	): vscode.Range;
+}
+
+/**
+ * ドキュメント情報
+ */
+export interface DocumentInfo {
+	uri: vscode.Uri;
+	text: string;
+	languageId: string;
+	lineCount: number;
+}
+
+/**
+ * VscodeDocumentClient
+ * VSCodeのテキストドキュメント操作のラッパー
+ */
+export class VscodeDocumentClient {
+	constructor(private readonly deps: VscodeDocumentDeps) {}
+
+	/**
+	 * アクティブなドキュメントの情報を取得する
+	 */
+	getActiveDocument(): Result<DocumentInfo, DocumentNotFoundError> {
+		const editor = this.deps.getActiveTextEditor();
+		if (!editor) {
+			return err(new DocumentNotFoundError('アクティブなエディタがありません'));
+		}
+
+		const document = editor.document;
+		return ok({
+			uri: document.uri,
+			text: document.getText(),
+			languageId: document.languageId,
+			lineCount: document.lineCount,
+		});
+	}
+
+	/**
+	 * アクティブなドキュメントのテキストを取得する
+	 */
+	getActiveDocumentText(): Result<string, DocumentNotFoundError> {
+		const result = this.getActiveDocument();
+		return result.map((doc) => doc.text);
+	}
+
+	/**
+	 * アクティブなドキュメントのURIを取得する
+	 */
+	getActiveDocumentUri(): Result<vscode.Uri, DocumentNotFoundError> {
+		const result = this.getActiveDocument();
+		return result.map((doc) => doc.uri);
+	}
+
+	/**
+	 * アクティブなドキュメントのテキストを置換する
+	 */
+	async replaceDocumentText(
+		newText: string,
+	): Promise<Result<void, DocumentNotFoundError | DocumentEditError>> {
+		const uriResult = this.getActiveDocumentUri();
+		if (uriResult.isErr()) {
+			return err(uriResult.error);
+		}
+
+		const uri = uriResult.value;
+		const docResult = this.getActiveDocument();
+		if (docResult.isErr()) {
+			return err(docResult.error);
+		}
+
+		const lineCount = docResult.value.lineCount;
+		const lastLine = lineCount > 0 ? lineCount - 1 : 0;
+		const lastLineText = docResult.value.text.split('\n')[lastLine] ?? '';
+
+		const edit = this.deps.createWorkspaceEdit();
+		const fullRange = this.deps.createRange(0, 0, lastLine, lastLineText.length);
+		edit.replace(uri, fullRange, newText);
+
+		const success = await this.deps.applyEdit(edit);
+		if (!success) {
+			return err(new DocumentEditError('ドキュメントの編集に失敗しました'));
+		}
+
+		return ok(undefined);
+	}
+
+	/**
+	 * 指定URIのドキュメントを開いてテキストを取得する
+	 */
+	async openAndGetText(uri: vscode.Uri): Promise<Result<string, DocumentNotFoundError>> {
+		try {
+			const document = await this.deps.openTextDocument(uri);
+			return ok(document.getText());
+		} catch (error) {
+			return err(
+				new DocumentNotFoundError(
+					`ドキュメントを開けませんでした: ${error instanceof Error ? error.message : String(error)}`,
+				),
+			);
+		}
+	}
+}


### PR DESCRIPTION
- VscodeDocumentClient: VSCodeドキュメント操作のラッパー
- VscodeConfigClient: VSCode設定APIのラッパー
- MarkdownTaskRepository: TaskRepositoryポートの実装
- VscodeConfigProvider: ConfigProviderの実装（VSCode設定）
- FrontmatterConfigProvider: ConfigProviderの実装（フロントマター）

38件のユニットテストを追加（計171件）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Infrastructure layer (Phase 5) implementation completed with enhanced document handling and multi-source configuration management (VSCode settings and document frontmatter)

* **Tests**
  * Added 38 comprehensive unit tests for infrastructure components (171 total tests)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->