### PR TITLE
Start Phase 6 implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,8 @@ src/
 ## 現在のステータス
 
 - **バージョン**: 0.0.1（開発中）
-- **状態**: Phase 5（インフラストラクチャ層の実装）完了
-- **次のステップ**: Phase 6（インターフェース層の実装）へ
+- **状態**: Phase 6（インターフェース層の実装）完了
+- **次のステップ**: Phase 7（WebView UIの実装）へ
 
 ### 完了済みフェーズ
 
@@ -215,6 +215,14 @@ src/
   - VscodeConfigProvider: ConfigProviderの実装（VSCode設定）
   - FrontmatterConfigProvider: ConfigProviderの実装（フロントマター）
   - 38件のユニットテスト（計171件）
+
+- ✅ Phase 6: インターフェース層の実装
+  - WebViewMessageClient: WebViewへのメッセージ送受信
+  - TaskController: タスク操作のエントリーポイント
+  - ConfigController: 設定操作のエントリーポイント
+  - WebViewMessageHandler: WebViewからのメッセージハンドリング
+  - メッセージ型定義（Extension ⇔ WebView間の通信プロトコル）
+  - 35件のユニットテスト（計206件）
 
 ---
 

--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -192,19 +192,28 @@ src/
 
 ---
 
-### Phase 6: インターフェース層の実装
+### Phase 6: インターフェース層の実装 ✅
 
 **目標**: 外部からのリクエストを受け付け、ユースケースを呼び出す
 
 #### 6.1 Client実装（外部通信）
 
-- [ ] `WebViewMessageClient` - WebViewへのメッセージ送受信
+- [x] `WebViewMessageClient` - WebViewへのメッセージ送受信
 
 #### 6.2 Adapter実装（Portの実装）
 
-- [ ] `TaskController` - タスク操作のエントリーポイント
-- [ ] `ConfigController` - 設定操作のエントリーポイント
-- [ ] `WebViewMessageHandler` - WebViewからのメッセージハンドリング
+- [x] `TaskController` - タスク操作のエントリーポイント
+- [x] `ConfigController` - 設定操作のエントリーポイント
+- [x] `WebViewMessageHandler` - WebViewからのメッセージハンドリング
+
+#### 6.3 型定義
+
+- [x] メッセージ型（Extension ⇔ WebView間の通信プロトコル）
+- [x] TaskDto（タスクのデータ転送オブジェクト）
+
+#### 6.4 テスト
+
+- [x] 35件のユニットテストを追加（計206件）
 
 ---
 
@@ -346,8 +355,9 @@ vscode.postMessage({ type: 'UPDATE_TASK', payload: { id, status } });
 3. ~~Phase 3: Markdownパーサーの実装~~ ✅
 4. ~~Phase 4: アプリケーション層の実装~~ ✅
 5. ~~Phase 5: インフラストラクチャ層の実装~~ ✅
-6. Phase 6: インターフェース層の実装
-7. 各フェーズ完了後にレビュー・調整
+6. ~~Phase 6: インターフェース層の実装~~ ✅
+7. Phase 7: WebView UIの実装
+8. 各フェーズ完了後にレビュー・調整
 
 ---
 
@@ -366,3 +376,5 @@ vscode.postMessage({ type: 'UPDATE_TASK', payload: { id, status } });
 | 2025-01-XX | Phase 1, 2 完了。Phase 3 詳細化（タスクID生成、重複検出、部分編集方針） |
 | 2025-01-XX | Phase 3 完了。MarkdownParser、MarkdownSerializer実装（計42件のテスト） |
 | 2025-01-XX | Phase 4 完了。6つのユースケース実装（計133件のテスト） |
+| 2025-01-XX | Phase 5 完了。インフラストラクチャ層のアダプター実装（計171件のテスト） |
+| 2025-01-XX | Phase 6 完了。インターフェース層の実装（計206件のテスト） |

--- a/src/interface/adapters/configController.test.ts
+++ b/src/interface/adapters/configController.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GetConfigUseCase } from '../../application/usecases';
+import type { KanbanConfig } from '../../domain/ports/configProvider';
+import { ConfigController } from './configController';
+
+describe('ConfigController', () => {
+	let mockGetConfigUseCase: GetConfigUseCase;
+	let controller: ConfigController;
+
+	const mockConfig: KanbanConfig = {
+		statuses: ['todo', 'in-progress', 'done'],
+		doneStatuses: ['done'],
+		defaultStatus: 'todo',
+		defaultDoneStatus: 'done',
+		sortBy: 'markdown',
+		syncCheckboxWithDone: true,
+	};
+
+	beforeEach(() => {
+		mockGetConfigUseCase = {
+			execute: vi.fn().mockResolvedValue(mockConfig),
+			get: vi.fn().mockImplementation((key: keyof KanbanConfig) => {
+				return Promise.resolve(mockConfig[key]);
+			}),
+		} as unknown as GetConfigUseCase;
+
+		controller = new ConfigController(mockGetConfigUseCase);
+	});
+
+	describe('getConfig', () => {
+		it('設定を取得できる', async () => {
+			const result = await controller.getConfig();
+
+			expect(result).toEqual(mockConfig);
+			expect(mockGetConfigUseCase.execute).toHaveBeenCalled();
+		});
+	});
+
+	describe('get', () => {
+		it('特定の設定項目を取得できる', async () => {
+			const statuses = await controller.get('statuses');
+
+			expect(statuses).toEqual(['todo', 'in-progress', 'done']);
+			expect(mockGetConfigUseCase.get).toHaveBeenCalledWith('statuses');
+		});
+
+		it('doneStatusesを取得できる', async () => {
+			const doneStatuses = await controller.get('doneStatuses');
+
+			expect(doneStatuses).toEqual(['done']);
+		});
+
+		it('sortByを取得できる', async () => {
+			const sortBy = await controller.get('sortBy');
+
+			expect(sortBy).toBe('markdown');
+		});
+	});
+});

--- a/src/interface/adapters/configController.ts
+++ b/src/interface/adapters/configController.ts
@@ -1,0 +1,24 @@
+import type { GetConfigUseCase } from '../../application/usecases';
+import type { KanbanConfig } from '../../domain/ports/configProvider';
+
+/**
+ * ConfigController
+ * 設定操作のエントリーポイント
+ */
+export class ConfigController {
+	constructor(private readonly getConfigUseCase: GetConfigUseCase) {}
+
+	/**
+	 * 設定を取得する
+	 */
+	async getConfig(): Promise<KanbanConfig> {
+		return this.getConfigUseCase.execute();
+	}
+
+	/**
+	 * 特定の設定項目を取得する
+	 */
+	async get<K extends keyof KanbanConfig>(key: K): Promise<KanbanConfig[K]> {
+		return this.getConfigUseCase.get(key);
+	}
+}

--- a/src/interface/adapters/index.ts
+++ b/src/interface/adapters/index.ts
@@ -1,2 +1,4 @@
-// Interface Ports
-export {};
+// Interface Adapters
+export { ConfigController } from './configController';
+export { type CreateTaskDto, TaskController, type UpdateTaskDto } from './taskController';
+export { WebViewMessageHandler } from './webViewMessageHandler';

--- a/src/interface/adapters/taskController.test.ts
+++ b/src/interface/adapters/taskController.test.ts
@@ -1,0 +1,225 @@
+import { err, ok } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+	ChangeTaskStatusUseCase,
+	CreateTaskUseCase,
+	DeleteTaskUseCase,
+	GetTasksUseCase,
+	UpdateTaskUseCase,
+} from '../../application/usecases';
+import { Task } from '../../domain/entities/task';
+import { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
+import { TaskParseError } from '../../domain/errors/taskParseError';
+import { Path } from '../../domain/valueObjects/path';
+import { Status } from '../../domain/valueObjects/status';
+import { TaskController } from './taskController';
+
+describe('TaskController', () => {
+	let mockGetTasksUseCase: GetTasksUseCase;
+	let mockCreateTaskUseCase: CreateTaskUseCase;
+	let mockUpdateTaskUseCase: UpdateTaskUseCase;
+	let mockDeleteTaskUseCase: DeleteTaskUseCase;
+	let mockChangeTaskStatusUseCase: ChangeTaskStatusUseCase;
+	let controller: TaskController;
+
+	const mockTask = Task.create({
+		id: 'task-1',
+		title: 'Test Task',
+		status: Status.create('todo')._unsafeUnwrap(),
+		path: Path.create(['Project']),
+		isChecked: false,
+		metadata: { priority: 'high' },
+	});
+
+	beforeEach(() => {
+		mockGetTasksUseCase = {
+			execute: vi.fn().mockResolvedValue(ok([mockTask])),
+			executeByPath: vi.fn().mockResolvedValue(ok([mockTask])),
+		} as unknown as GetTasksUseCase;
+
+		mockCreateTaskUseCase = {
+			execute: vi.fn().mockResolvedValue(ok(mockTask)),
+		} as unknown as CreateTaskUseCase;
+
+		mockUpdateTaskUseCase = {
+			execute: vi.fn().mockResolvedValue(ok(mockTask)),
+		} as unknown as UpdateTaskUseCase;
+
+		mockDeleteTaskUseCase = {
+			execute: vi.fn().mockResolvedValue(ok(undefined)),
+		} as unknown as DeleteTaskUseCase;
+
+		mockChangeTaskStatusUseCase = {
+			execute: vi.fn().mockResolvedValue(ok(mockTask)),
+		} as unknown as ChangeTaskStatusUseCase;
+
+		controller = new TaskController(
+			mockGetTasksUseCase,
+			mockCreateTaskUseCase,
+			mockUpdateTaskUseCase,
+			mockDeleteTaskUseCase,
+			mockChangeTaskStatusUseCase,
+		);
+	});
+
+	describe('getTasks', () => {
+		it('全タスクをDTO形式で取得できる', async () => {
+			const result = await controller.getTasks();
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.value).toHaveLength(1);
+				expect(result.value[0]).toEqual({
+					id: 'task-1',
+					title: 'Test Task',
+					status: 'todo',
+					path: ['Project'],
+					isChecked: false,
+					metadata: { priority: 'high' },
+				});
+			}
+		});
+
+		it('エラー時はエラーを返す', async () => {
+			mockGetTasksUseCase.execute = vi
+				.fn()
+				.mockResolvedValue(err(new TaskParseError(1, 'Parse error')));
+
+			const result = await controller.getTasks();
+
+			expect(result.isErr()).toBe(true);
+		});
+	});
+
+	describe('createTask', () => {
+		it('タスクを作成してDTO形式で返す', async () => {
+			const result = await controller.createTask({
+				title: 'New Task',
+				path: ['Project'],
+			});
+
+			expect(result.isOk()).toBe(true);
+			expect(mockCreateTaskUseCase.execute).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'New Task',
+				}),
+			);
+		});
+
+		it('ステータス付きでタスクを作成できる', async () => {
+			await controller.createTask({
+				title: 'New Task',
+				path: ['Project'],
+				status: 'in-progress',
+			});
+
+			expect(mockCreateTaskUseCase.execute).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'New Task',
+					status: expect.objectContaining({ _value: 'in-progress' }),
+				}),
+			);
+		});
+
+		it('無効なステータスの場合はエラーを返す', async () => {
+			const result = await controller.createTask({
+				title: 'New Task',
+				path: ['Project'],
+				status: '', // 空文字は無効
+			});
+
+			expect(result.isErr()).toBe(true);
+		});
+	});
+
+	describe('updateTask', () => {
+		it('タスクを更新してDTO形式で返す', async () => {
+			const result = await controller.updateTask({
+				id: 'task-1',
+				title: 'Updated Task',
+			});
+
+			expect(result.isOk()).toBe(true);
+			expect(mockUpdateTaskUseCase.execute).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'task-1',
+					title: 'Updated Task',
+				}),
+			);
+		});
+
+		it('パスを更新できる', async () => {
+			await controller.updateTask({
+				id: 'task-1',
+				path: ['New', 'Path'],
+			});
+
+			expect(mockUpdateTaskUseCase.execute).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'task-1',
+					path: expect.objectContaining({ _segments: ['New', 'Path'] }),
+				}),
+			);
+		});
+
+		it('存在しないタスクの場合はエラーを返す', async () => {
+			mockUpdateTaskUseCase.execute = vi
+				.fn()
+				.mockResolvedValue(err(new TaskNotFoundError('task-999')));
+
+			const result = await controller.updateTask({
+				id: 'task-999',
+				title: 'Updated',
+			});
+
+			expect(result.isErr()).toBe(true);
+		});
+	});
+
+	describe('deleteTask', () => {
+		it('タスクを削除できる', async () => {
+			const result = await controller.deleteTask('task-1');
+
+			expect(result.isOk()).toBe(true);
+			expect(mockDeleteTaskUseCase.execute).toHaveBeenCalledWith('task-1');
+		});
+
+		it('存在しないタスクの場合はエラーを返す', async () => {
+			mockDeleteTaskUseCase.execute = vi
+				.fn()
+				.mockResolvedValue(err(new TaskNotFoundError('task-999')));
+
+			const result = await controller.deleteTask('task-999');
+
+			expect(result.isErr()).toBe(true);
+		});
+	});
+
+	describe('changeTaskStatus', () => {
+		it('タスクのステータスを変更できる', async () => {
+			const result = await controller.changeTaskStatus('task-1', 'done');
+
+			expect(result.isOk()).toBe(true);
+			expect(mockChangeTaskStatusUseCase.execute).toHaveBeenCalledWith(
+				'task-1',
+				expect.objectContaining({ _value: 'done' }),
+			);
+		});
+
+		it('無効なステータスの場合はエラーを返す', async () => {
+			const result = await controller.changeTaskStatus('task-1', '');
+
+			expect(result.isErr()).toBe(true);
+		});
+
+		it('存在しないタスクの場合はエラーを返す', async () => {
+			mockChangeTaskStatusUseCase.execute = vi
+				.fn()
+				.mockResolvedValue(err(new TaskNotFoundError('task-999')));
+
+			const result = await controller.changeTaskStatus('task-999', 'done');
+
+			expect(result.isErr()).toBe(true);
+		});
+	});
+});

--- a/src/interface/adapters/taskController.ts
+++ b/src/interface/adapters/taskController.ts
@@ -1,0 +1,140 @@
+import { err, type Result } from 'neverthrow';
+import type {
+	ChangeTaskStatusUseCase,
+	CreateTaskInput,
+	CreateTaskUseCase,
+	DeleteTaskUseCase,
+	GetTasksUseCase,
+	UpdateTaskInput,
+	UpdateTaskUseCase,
+} from '../../application/usecases';
+import type { Task, TaskMetadata } from '../../domain/entities/task';
+import type { InvalidStatusError } from '../../domain/errors/invalidStatusError';
+import type { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
+import type { TaskParseError } from '../../domain/errors/taskParseError';
+import { Path } from '../../domain/valueObjects/path';
+import { Status } from '../../domain/valueObjects/status';
+import type { TaskDto } from '../types/messages';
+
+/**
+ * タスク作成リクエスト
+ */
+export interface CreateTaskDto {
+	title: string;
+	path: string[];
+	status?: string;
+	metadata?: TaskMetadata;
+}
+
+/**
+ * タスク更新リクエスト
+ */
+export interface UpdateTaskDto {
+	id: string;
+	title?: string;
+	path?: string[];
+	metadata?: TaskMetadata;
+}
+
+/**
+ * TaskController
+ * タスク操作のエントリーポイント
+ */
+export class TaskController {
+	constructor(
+		private readonly getTasksUseCase: GetTasksUseCase,
+		private readonly createTaskUseCase: CreateTaskUseCase,
+		private readonly updateTaskUseCase: UpdateTaskUseCase,
+		private readonly deleteTaskUseCase: DeleteTaskUseCase,
+		private readonly changeTaskStatusUseCase: ChangeTaskStatusUseCase,
+	) {}
+
+	/**
+	 * 全タスクを取得する
+	 */
+	async getTasks(): Promise<Result<TaskDto[], TaskParseError>> {
+		const result = await this.getTasksUseCase.execute();
+		return result.map((tasks) => tasks.map(this.toDto));
+	}
+
+	/**
+	 * タスクを作成する
+	 */
+	async createTask(
+		dto: CreateTaskDto,
+	): Promise<Result<TaskDto, TaskNotFoundError | InvalidStatusError>> {
+		// ステータスの変換
+		let status: Status | undefined;
+		if (dto.status !== undefined) {
+			const statusResult = Status.create(dto.status);
+			if (statusResult.isErr()) {
+				return err(statusResult.error);
+			}
+			status = statusResult.value;
+		}
+
+		const input: CreateTaskInput = {
+			title: dto.title,
+			path: Path.create(dto.path),
+			status,
+			metadata: dto.metadata,
+		};
+
+		const result = await this.createTaskUseCase.execute(input);
+		return result.map(this.toDto);
+	}
+
+	/**
+	 * タスクを更新する
+	 */
+	async updateTask(
+		dto: UpdateTaskDto,
+	): Promise<Result<TaskDto, TaskNotFoundError | TaskParseError>> {
+		const input: UpdateTaskInput = {
+			id: dto.id,
+			title: dto.title,
+			path: dto.path ? Path.create(dto.path) : undefined,
+			metadata: dto.metadata,
+		};
+
+		const result = await this.updateTaskUseCase.execute(input);
+		return result.map(this.toDto);
+	}
+
+	/**
+	 * タスクを削除する
+	 */
+	async deleteTask(id: string): Promise<Result<void, TaskNotFoundError>> {
+		return this.deleteTaskUseCase.execute(id);
+	}
+
+	/**
+	 * タスクのステータスを変更する
+	 */
+	async changeTaskStatus(
+		id: string,
+		newStatus: string,
+	): Promise<Result<TaskDto, TaskNotFoundError | TaskParseError | InvalidStatusError>> {
+		const statusResult = Status.create(newStatus);
+		if (statusResult.isErr()) {
+			return err(statusResult.error);
+		}
+
+		const result = await this.changeTaskStatusUseCase.execute(id, statusResult.value);
+		return result.map(this.toDto);
+	}
+
+	/**
+	 * TaskエンティティをDTOに変換する
+	 */
+	private toDto = (task: Task): TaskDto => {
+		return {
+			id: task.id,
+			title: task.title,
+			status: task.status.value,
+			path: [...task.path.segments],
+			isChecked: task.isChecked,
+			metadata: task.metadata,
+		};
+	};
+}

--- a/src/interface/adapters/webViewMessageHandler.test.ts
+++ b/src/interface/adapters/webViewMessageHandler.test.ts
@@ -1,0 +1,216 @@
+import { err, ok } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
+import { TaskParseError } from '../../domain/errors/taskParseError';
+import type { KanbanConfig } from '../../domain/ports/configProvider';
+import type { WebViewMessageClient } from '../clients/webViewMessageClient';
+import type { TaskDto, WebViewToExtensionMessage } from '../types/messages';
+import type { ConfigController } from './configController';
+import type { TaskController } from './taskController';
+import { WebViewMessageHandler } from './webViewMessageHandler';
+
+describe('WebViewMessageHandler', () => {
+	let mockTaskController: TaskController;
+	let mockConfigController: ConfigController;
+	let mockMessageClient: WebViewMessageClient;
+	let handler: WebViewMessageHandler;
+
+	const mockTaskDto: TaskDto = {
+		id: 'task-1',
+		title: 'Test Task',
+		status: 'todo',
+		path: ['Project'],
+		isChecked: false,
+		metadata: {},
+	};
+
+	const mockConfig: KanbanConfig = {
+		statuses: ['todo', 'in-progress', 'done'],
+		doneStatuses: ['done'],
+		defaultStatus: 'todo',
+		defaultDoneStatus: 'done',
+		sortBy: 'markdown',
+		syncCheckboxWithDone: true,
+	};
+
+	beforeEach(() => {
+		mockTaskController = {
+			getTasks: vi.fn().mockResolvedValue(ok([mockTaskDto])),
+			createTask: vi.fn().mockResolvedValue(ok(mockTaskDto)),
+			updateTask: vi.fn().mockResolvedValue(ok(mockTaskDto)),
+			deleteTask: vi.fn().mockResolvedValue(ok(undefined)),
+			changeTaskStatus: vi.fn().mockResolvedValue(ok(mockTaskDto)),
+		} as unknown as TaskController;
+
+		mockConfigController = {
+			getConfig: vi.fn().mockResolvedValue(mockConfig),
+			get: vi.fn(),
+		} as unknown as ConfigController;
+
+		mockMessageClient = {
+			postMessage: vi.fn(),
+			sendTasksUpdated: vi.fn(),
+			sendTaskCreated: vi.fn(),
+			sendTaskUpdated: vi.fn(),
+			sendTaskDeleted: vi.fn(),
+			sendConfigUpdated: vi.fn(),
+			sendError: vi.fn(),
+		} as unknown as WebViewMessageClient;
+
+		handler = new WebViewMessageHandler(
+			mockTaskController,
+			mockConfigController,
+			mockMessageClient,
+		);
+	});
+
+	describe('handleMessage', () => {
+		describe('GET_TASKS', () => {
+			it('タスク一覧を取得して送信する', async () => {
+				const message: WebViewToExtensionMessage = { type: 'GET_TASKS' };
+
+				await handler.handleMessage(message);
+
+				expect(mockTaskController.getTasks).toHaveBeenCalled();
+				expect(mockMessageClient.sendTasksUpdated).toHaveBeenCalledWith([mockTaskDto]);
+			});
+
+			it('エラー時はエラーメッセージを送信する', async () => {
+				mockTaskController.getTasks = vi
+					.fn()
+					.mockResolvedValue(err(new TaskParseError(1, 'Parse error')));
+				const message: WebViewToExtensionMessage = { type: 'GET_TASKS' };
+
+				await handler.handleMessage(message);
+
+				expect(mockMessageClient.sendError).toHaveBeenCalledWith(
+					'Failed to parse task at line 1: Parse error',
+					'TaskParseError',
+				);
+			});
+		});
+
+		describe('CREATE_TASK', () => {
+			it('タスクを作成して送信する', async () => {
+				const message: WebViewToExtensionMessage = {
+					type: 'CREATE_TASK',
+					payload: {
+						title: 'New Task',
+						path: ['Project'],
+					},
+				};
+
+				await handler.handleMessage(message);
+
+				expect(mockTaskController.createTask).toHaveBeenCalledWith({
+					title: 'New Task',
+					path: ['Project'],
+					status: undefined,
+					metadata: undefined,
+				});
+				expect(mockMessageClient.sendTaskCreated).toHaveBeenCalledWith(mockTaskDto);
+			});
+
+			it('ステータス付きでタスクを作成できる', async () => {
+				const message: WebViewToExtensionMessage = {
+					type: 'CREATE_TASK',
+					payload: {
+						title: 'New Task',
+						path: ['Project'],
+						status: 'in-progress',
+					},
+				};
+
+				await handler.handleMessage(message);
+
+				expect(mockTaskController.createTask).toHaveBeenCalledWith({
+					title: 'New Task',
+					path: ['Project'],
+					status: 'in-progress',
+					metadata: undefined,
+				});
+			});
+		});
+
+		describe('UPDATE_TASK', () => {
+			it('タスクを更新して送信する', async () => {
+				const message: WebViewToExtensionMessage = {
+					type: 'UPDATE_TASK',
+					payload: {
+						id: 'task-1',
+						title: 'Updated Task',
+					},
+				};
+
+				await handler.handleMessage(message);
+
+				expect(mockTaskController.updateTask).toHaveBeenCalledWith({
+					id: 'task-1',
+					title: 'Updated Task',
+					path: undefined,
+					metadata: undefined,
+				});
+				expect(mockMessageClient.sendTaskUpdated).toHaveBeenCalledWith(mockTaskDto);
+			});
+
+			it('エラー時はエラーメッセージを送信する', async () => {
+				mockTaskController.updateTask = vi
+					.fn()
+					.mockResolvedValue(err(new TaskNotFoundError('task-1')));
+				const message: WebViewToExtensionMessage = {
+					type: 'UPDATE_TASK',
+					payload: { id: 'task-1', title: 'Updated' },
+				};
+
+				await handler.handleMessage(message);
+
+				expect(mockMessageClient.sendError).toHaveBeenCalledWith(
+					'Task not found: task-1',
+					'TaskNotFoundError',
+				);
+			});
+		});
+
+		describe('DELETE_TASK', () => {
+			it('タスクを削除して送信する', async () => {
+				const message: WebViewToExtensionMessage = {
+					type: 'DELETE_TASK',
+					payload: { id: 'task-1' },
+				};
+
+				await handler.handleMessage(message);
+
+				expect(mockTaskController.deleteTask).toHaveBeenCalledWith('task-1');
+				expect(mockMessageClient.sendTaskDeleted).toHaveBeenCalledWith('task-1');
+			});
+		});
+
+		describe('CHANGE_TASK_STATUS', () => {
+			it('タスクのステータスを変更して送信する', async () => {
+				const message: WebViewToExtensionMessage = {
+					type: 'CHANGE_TASK_STATUS',
+					payload: {
+						id: 'task-1',
+						status: 'done',
+					},
+				};
+
+				await handler.handleMessage(message);
+
+				expect(mockTaskController.changeTaskStatus).toHaveBeenCalledWith('task-1', 'done');
+				expect(mockMessageClient.sendTaskUpdated).toHaveBeenCalledWith(mockTaskDto);
+			});
+		});
+
+		describe('GET_CONFIG', () => {
+			it('設定を取得して送信する', async () => {
+				const message: WebViewToExtensionMessage = { type: 'GET_CONFIG' };
+
+				await handler.handleMessage(message);
+
+				expect(mockConfigController.getConfig).toHaveBeenCalled();
+				expect(mockMessageClient.sendConfigUpdated).toHaveBeenCalledWith(mockConfig);
+			});
+		});
+	});
+});

--- a/src/interface/adapters/webViewMessageHandler.ts
+++ b/src/interface/adapters/webViewMessageHandler.ts
@@ -1,0 +1,148 @@
+import { logger } from '../../shared';
+import type { WebViewMessageClient } from '../clients/webViewMessageClient';
+import type { WebViewToExtensionMessage } from '../types/messages';
+import type { ConfigController } from './configController';
+import type { TaskController } from './taskController';
+
+/**
+ * WebViewMessageHandler
+ * WebViewからのメッセージをハンドリングする
+ */
+export class WebViewMessageHandler {
+	constructor(
+		private readonly taskController: TaskController,
+		private readonly configController: ConfigController,
+		private readonly messageClient: WebViewMessageClient,
+	) {}
+
+	/**
+	 * メッセージを処理する
+	 */
+	async handleMessage(message: WebViewToExtensionMessage): Promise<void> {
+		logger.info(`Handling message: ${message.type}`);
+
+		switch (message.type) {
+			case 'GET_TASKS':
+				await this.handleGetTasks();
+				break;
+			case 'CREATE_TASK':
+				await this.handleCreateTask(message.payload);
+				break;
+			case 'UPDATE_TASK':
+				await this.handleUpdateTask(message.payload);
+				break;
+			case 'DELETE_TASK':
+				await this.handleDeleteTask(message.payload.id);
+				break;
+			case 'CHANGE_TASK_STATUS':
+				await this.handleChangeTaskStatus(message.payload.id, message.payload.status);
+				break;
+			case 'GET_CONFIG':
+				await this.handleGetConfig();
+				break;
+			default:
+				logger.error(`Unknown message type: ${(message as { type: string }).type}`);
+		}
+	}
+
+	/**
+	 * タスク一覧取得を処理する
+	 */
+	private async handleGetTasks(): Promise<void> {
+		const result = await this.taskController.getTasks();
+
+		if (result.isOk()) {
+			this.messageClient.sendTasksUpdated(result.value);
+		} else {
+			this.sendError(result.error);
+		}
+	}
+
+	/**
+	 * タスク作成を処理する
+	 */
+	private async handleCreateTask(payload: {
+		title: string;
+		path: string[];
+		status?: string;
+		metadata?: Record<string, string>;
+	}): Promise<void> {
+		const result = await this.taskController.createTask({
+			title: payload.title,
+			path: payload.path,
+			status: payload.status,
+			metadata: payload.metadata,
+		});
+
+		if (result.isOk()) {
+			this.messageClient.sendTaskCreated(result.value);
+		} else {
+			this.sendError(result.error);
+		}
+	}
+
+	/**
+	 * タスク更新を処理する
+	 */
+	private async handleUpdateTask(payload: {
+		id: string;
+		title?: string;
+		path?: string[];
+		metadata?: Record<string, string>;
+	}): Promise<void> {
+		const result = await this.taskController.updateTask({
+			id: payload.id,
+			title: payload.title,
+			path: payload.path,
+			metadata: payload.metadata,
+		});
+
+		if (result.isOk()) {
+			this.messageClient.sendTaskUpdated(result.value);
+		} else {
+			this.sendError(result.error);
+		}
+	}
+
+	/**
+	 * タスク削除を処理する
+	 */
+	private async handleDeleteTask(id: string): Promise<void> {
+		const result = await this.taskController.deleteTask(id);
+
+		if (result.isOk()) {
+			this.messageClient.sendTaskDeleted(id);
+		} else {
+			this.sendError(result.error);
+		}
+	}
+
+	/**
+	 * タスクステータス変更を処理する
+	 */
+	private async handleChangeTaskStatus(id: string, status: string): Promise<void> {
+		const result = await this.taskController.changeTaskStatus(id, status);
+
+		if (result.isOk()) {
+			this.messageClient.sendTaskUpdated(result.value);
+		} else {
+			this.sendError(result.error);
+		}
+	}
+
+	/**
+	 * 設定取得を処理する
+	 */
+	private async handleGetConfig(): Promise<void> {
+		const config = await this.configController.getConfig();
+		this.messageClient.sendConfigUpdated(config);
+	}
+
+	/**
+	 * エラーを送信する
+	 */
+	private sendError(error: Error & { _tag?: string }): void {
+		logger.error(`Error: ${error.message}`, { errorType: error._tag, message: error.message });
+		this.messageClient.sendError(error.message, error._tag);
+	}
+}

--- a/src/interface/clients/index.ts
+++ b/src/interface/clients/index.ts
@@ -1,2 +1,2 @@
 // Interface Clients
-export {};
+export { WebViewMessageClient, type WebViewMessageDeps } from './webViewMessageClient';

--- a/src/interface/clients/webViewMessageClient.test.ts
+++ b/src/interface/clients/webViewMessageClient.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExtensionToWebViewMessage, TaskDto } from '../types/messages';
+import { WebViewMessageClient, type WebViewMessageDeps } from './webViewMessageClient';
+
+describe('WebViewMessageClient', () => {
+	let deps: WebViewMessageDeps;
+	let client: WebViewMessageClient;
+
+	const mockTask: TaskDto = {
+		id: 'task-1',
+		title: 'Test Task',
+		status: 'todo',
+		path: ['Project', 'Feature'],
+		isChecked: false,
+		metadata: {},
+	};
+
+	beforeEach(() => {
+		deps = {
+			postMessage: vi.fn(),
+		};
+		client = new WebViewMessageClient(deps);
+	});
+
+	describe('postMessage', () => {
+		it('メッセージを送信できる', () => {
+			const message: ExtensionToWebViewMessage = {
+				type: 'TASKS_UPDATED',
+				payload: { tasks: [mockTask] },
+			};
+
+			client.postMessage(message);
+
+			expect(deps.postMessage).toHaveBeenCalledWith(message);
+		});
+	});
+
+	describe('sendTasksUpdated', () => {
+		it('タスク一覧更新メッセージを送信できる', () => {
+			const tasks: TaskDto[] = [mockTask];
+
+			client.sendTasksUpdated(tasks);
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'TASKS_UPDATED',
+				payload: { tasks },
+			});
+		});
+
+		it('空のタスク一覧を送信できる', () => {
+			client.sendTasksUpdated([]);
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'TASKS_UPDATED',
+				payload: { tasks: [] },
+			});
+		});
+	});
+
+	describe('sendTaskCreated', () => {
+		it('タスク作成成功メッセージを送信できる', () => {
+			client.sendTaskCreated(mockTask);
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'TASK_CREATED',
+				payload: { task: mockTask },
+			});
+		});
+	});
+
+	describe('sendTaskUpdated', () => {
+		it('タスク更新成功メッセージを送信できる', () => {
+			client.sendTaskUpdated(mockTask);
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'TASK_UPDATED',
+				payload: { task: mockTask },
+			});
+		});
+	});
+
+	describe('sendTaskDeleted', () => {
+		it('タスク削除成功メッセージを送信できる', () => {
+			client.sendTaskDeleted('task-1');
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'TASK_DELETED',
+				payload: { id: 'task-1' },
+			});
+		});
+	});
+
+	describe('sendConfigUpdated', () => {
+		it('設定更新メッセージを送信できる', () => {
+			const config = {
+				statuses: ['todo', 'in-progress', 'done'],
+				doneStatuses: ['done'],
+				defaultStatus: 'todo',
+				defaultDoneStatus: 'done',
+				sortBy: 'markdown' as const,
+				syncCheckboxWithDone: true,
+			};
+
+			client.sendConfigUpdated(config);
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'CONFIG_UPDATED',
+				payload: { config },
+			});
+		});
+	});
+
+	describe('sendError', () => {
+		it('エラーメッセージを送信できる', () => {
+			client.sendError('Something went wrong');
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'ERROR',
+				payload: { message: 'Something went wrong' },
+			});
+		});
+
+		it('エラーコード付きでエラーメッセージを送信できる', () => {
+			client.sendError('Task not found', 'TASK_NOT_FOUND');
+
+			expect(deps.postMessage).toHaveBeenCalledWith({
+				type: 'ERROR',
+				payload: { message: 'Task not found', code: 'TASK_NOT_FOUND' },
+			});
+		});
+	});
+});

--- a/src/interface/clients/webViewMessageClient.ts
+++ b/src/interface/clients/webViewMessageClient.ts
@@ -1,0 +1,85 @@
+import type { KanbanConfig } from '../../domain/ports/configProvider';
+import type { ExtensionToWebViewMessage, TaskDto } from '../types/messages';
+
+/**
+ * WebView通信の依存性インターフェース
+ * テスト時にモック可能にするため
+ */
+export interface WebViewMessageDeps {
+	postMessage(message: ExtensionToWebViewMessage): void;
+}
+
+/**
+ * WebViewMessageClient
+ * WebViewへのメッセージ送信を担当するクライアント
+ */
+export class WebViewMessageClient {
+	constructor(private readonly deps: WebViewMessageDeps) {}
+
+	/**
+	 * メッセージを送信する
+	 */
+	postMessage(message: ExtensionToWebViewMessage): void {
+		this.deps.postMessage(message);
+	}
+
+	/**
+	 * タスク一覧更新メッセージを送信する
+	 */
+	sendTasksUpdated(tasks: TaskDto[]): void {
+		this.postMessage({
+			type: 'TASKS_UPDATED',
+			payload: { tasks },
+		});
+	}
+
+	/**
+	 * タスク作成成功メッセージを送信する
+	 */
+	sendTaskCreated(task: TaskDto): void {
+		this.postMessage({
+			type: 'TASK_CREATED',
+			payload: { task },
+		});
+	}
+
+	/**
+	 * タスク更新成功メッセージを送信する
+	 */
+	sendTaskUpdated(task: TaskDto): void {
+		this.postMessage({
+			type: 'TASK_UPDATED',
+			payload: { task },
+		});
+	}
+
+	/**
+	 * タスク削除成功メッセージを送信する
+	 */
+	sendTaskDeleted(id: string): void {
+		this.postMessage({
+			type: 'TASK_DELETED',
+			payload: { id },
+		});
+	}
+
+	/**
+	 * 設定更新メッセージを送信する
+	 */
+	sendConfigUpdated(config: KanbanConfig): void {
+		this.postMessage({
+			type: 'CONFIG_UPDATED',
+			payload: { config },
+		});
+	}
+
+	/**
+	 * エラーメッセージを送信する
+	 */
+	sendError(message: string, code?: string): void {
+		this.postMessage({
+			type: 'ERROR',
+			payload: code ? { message, code } : { message },
+		});
+	}
+}

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -2,3 +2,4 @@
 
 export * from './adapters';
 export * from './clients';
+export * from './types';

--- a/src/interface/types/index.ts
+++ b/src/interface/types/index.ts
@@ -1,0 +1,2 @@
+// Interface Types
+export * from './messages';

--- a/src/interface/types/messages.ts
+++ b/src/interface/types/messages.ts
@@ -1,0 +1,176 @@
+import type { TaskMetadata } from '../../domain/entities/task';
+import type { KanbanConfig } from '../../domain/ports/configProvider';
+
+/**
+ * タスクDTO（Extension ⇔ WebView間の通信用）
+ */
+export interface TaskDto {
+	id: string;
+	title: string;
+	status: string;
+	path: string[];
+	isChecked: boolean;
+	metadata: TaskMetadata;
+}
+
+// =============================================================================
+// WebView → Extension メッセージ
+// =============================================================================
+
+/**
+ * タスク一覧取得リクエスト
+ */
+export interface GetTasksRequest {
+	type: 'GET_TASKS';
+}
+
+/**
+ * タスク作成リクエスト
+ */
+export interface CreateTaskRequest {
+	type: 'CREATE_TASK';
+	payload: {
+		title: string;
+		path: string[];
+		status?: string;
+		metadata?: TaskMetadata;
+	};
+}
+
+/**
+ * タスク更新リクエスト
+ */
+export interface UpdateTaskRequest {
+	type: 'UPDATE_TASK';
+	payload: {
+		id: string;
+		title?: string;
+		path?: string[];
+		metadata?: TaskMetadata;
+	};
+}
+
+/**
+ * タスク削除リクエスト
+ */
+export interface DeleteTaskRequest {
+	type: 'DELETE_TASK';
+	payload: {
+		id: string;
+	};
+}
+
+/**
+ * タスクステータス変更リクエスト
+ */
+export interface ChangeTaskStatusRequest {
+	type: 'CHANGE_TASK_STATUS';
+	payload: {
+		id: string;
+		status: string;
+	};
+}
+
+/**
+ * 設定取得リクエスト
+ */
+export interface GetConfigRequest {
+	type: 'GET_CONFIG';
+}
+
+/**
+ * WebView → Extension の全メッセージタイプ
+ */
+export type WebViewToExtensionMessage =
+	| GetTasksRequest
+	| CreateTaskRequest
+	| UpdateTaskRequest
+	| DeleteTaskRequest
+	| ChangeTaskStatusRequest
+	| GetConfigRequest;
+
+// =============================================================================
+// Extension → WebView メッセージ
+// =============================================================================
+
+/**
+ * タスク一覧更新メッセージ
+ */
+export interface TasksUpdatedMessage {
+	type: 'TASKS_UPDATED';
+	payload: {
+		tasks: TaskDto[];
+	};
+}
+
+/**
+ * タスク作成成功メッセージ
+ */
+export interface TaskCreatedMessage {
+	type: 'TASK_CREATED';
+	payload: {
+		task: TaskDto;
+	};
+}
+
+/**
+ * タスク更新成功メッセージ
+ */
+export interface TaskUpdatedMessage {
+	type: 'TASK_UPDATED';
+	payload: {
+		task: TaskDto;
+	};
+}
+
+/**
+ * タスク削除成功メッセージ
+ */
+export interface TaskDeletedMessage {
+	type: 'TASK_DELETED';
+	payload: {
+		id: string;
+	};
+}
+
+/**
+ * 設定更新メッセージ
+ */
+export interface ConfigUpdatedMessage {
+	type: 'CONFIG_UPDATED';
+	payload: {
+		config: KanbanConfig;
+	};
+}
+
+/**
+ * エラーメッセージ
+ */
+export interface ErrorMessage {
+	type: 'ERROR';
+	payload: {
+		message: string;
+		code?: string;
+	};
+}
+
+/**
+ * Extension → WebView の全メッセージタイプ
+ */
+export type ExtensionToWebViewMessage =
+	| TasksUpdatedMessage
+	| TaskCreatedMessage
+	| TaskUpdatedMessage
+	| TaskDeletedMessage
+	| ConfigUpdatedMessage
+	| ErrorMessage;
+
+/**
+ * 全メッセージタイプ
+ */
+export type Message = WebViewToExtensionMessage | ExtensionToWebViewMessage;
+
+/**
+ * メッセージタイプの文字列リテラル
+ */
+export type MessageType = Message['type'];


### PR DESCRIPTION
Phase 6完了: 外部からのリクエストを受け付け、ユースケースを呼び出すインターフェース層を実装

実装内容:
- WebViewMessageClient: WebViewへのメッセージ送受信
- TaskController: タスク操作のエントリーポイント
- ConfigController: 設定操作のエントリーポイント
- WebViewMessageHandler: WebViewからのメッセージハンドリング
- メッセージ型定義（Extension ⇔ WebView間の通信プロトコル）
- TaskDto（タスクのデータ転送オブジェクト）

テスト:
- 35件のユニットテストを追加（計206件）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interface layer implementation complete with task and configuration management controllers.
  * WebView messaging client and strongly-typed bidirectional communication protocol established.

* **Tests**
  * Added 35 new unit tests (total 206) for controllers and messaging functionality.

* **Documentation**
  * Updated project roadmap: Phase 6 interface layer implementation complete; Phase 7 upcoming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->