### PR TITLE
Start Phase 7 Implementation

### DIFF
--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -217,27 +217,28 @@ src/
 
 ---
 
-### Phase 7: WebView UIの実装
+### Phase 7: WebView UIの実装 ✅
 
 **目標**: カンバンボードUIをReactで実装する
 
 #### 7.1 コンポーネント
 
-- [ ] `KanbanBoard` - ボード全体
-- [ ] `Column` - ステータスカラム
-- [ ] `TaskCard` - タスクカード
-- [ ] `TaskModal` - タスク作成・編集モーダル
-- [ ] `PathBadge` - パスバッジ
+- [x] `KanbanBoard` - ボード全体
+- [x] `Column` - ステータスカラム
+- [x] `TaskCard` - タスクカード
+- [x] `TaskModal` - タスク作成・編集モーダル
+- [x] `PathBadge` - パスバッジ
 
 #### 7.2 ドラッグ&ドロップ
 
-- [ ] 列間のドラッグ&ドロップ実装
-- [ ] ステータス変更の反映
+- [x] 列間のドラッグ&ドロップ実装（@dnd-kit/core使用）
+- [x] ステータス変更の反映
 
 #### 7.3 Extension通信
 
-- [ ] カスタムフック `useVscodeApi` の実装
-- [ ] メッセージ送受信の実装
+- [x] カスタムフック `useVscodeApi` の実装（型安全化）
+- [x] カスタムフック `useKanban` の実装（状態管理）
+- [x] メッセージ送受信の実装
 
 ---
 
@@ -356,8 +357,9 @@ vscode.postMessage({ type: 'UPDATE_TASK', payload: { id, status } });
 4. ~~Phase 4: アプリケーション層の実装~~ ✅
 5. ~~Phase 5: インフラストラクチャ層の実装~~ ✅
 6. ~~Phase 6: インターフェース層の実装~~ ✅
-7. Phase 7: WebView UIの実装
-8. 各フェーズ完了後にレビュー・調整
+7. ~~Phase 7: WebView UIの実装~~ ✅
+8. Phase 8: ブートストラップ層の実装
+9. 各フェーズ完了後にレビュー・調整
 
 ---
 
@@ -378,3 +380,4 @@ vscode.postMessage({ type: 'UPDATE_TASK', payload: { id, status } });
 | 2025-01-XX | Phase 4 完了。6つのユースケース実装（計133件のテスト） |
 | 2025-01-XX | Phase 5 完了。インフラストラクチャ層のアダプター実装（計171件のテスト） |
 | 2025-01-XX | Phase 6 完了。インターフェース層の実装（計206件のテスト） |
+| 2025-01-XX | Phase 7 完了。WebView UIの実装（KanbanBoard, Column, TaskCard, TaskModal, PathBadge, D&D） |

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -9,6 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",

--- a/src/webview/pnpm-lock.yaml
+++ b/src/webview/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -139,6 +148,28 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -785,6 +816,9 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -955,6 +989,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
@@ -1449,6 +1508,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tslib@2.8.1: {}
 
   tw-animate-css@1.4.0: {}
 

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -1,25 +1,9 @@
-import { useVscodeApi } from './hooks/useVscodeApi';
+import { KanbanBoard } from './components/kanban';
 
 function App() {
-	const { postMessage } = useVscodeApi();
-
-	const handleClick = () => {
-		postMessage({ type: 'HELLO', payload: 'Hello from WebView!' });
-	};
-
 	return (
-		<div className="min-h-screen bg-background p-4">
-			<h1 className="text-2xl font-bold text-foreground mb-4">Markdown Kanban</h1>
-			<p className="text-muted-foreground mb-4">
-				Welcome to the Markdown Kanban board. This is a placeholder for the kanban UI.
-			</p>
-			<button
-				type="button"
-				onClick={handleClick}
-				className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
-			>
-				Send Message to Extension
-			</button>
+		<div className="h-screen bg-background">
+			<KanbanBoard />
 		</div>
 	);
 }

--- a/src/webview/src/components/index.ts
+++ b/src/webview/src/components/index.ts
@@ -1,1 +1,2 @@
-// UI Components
+// Kanban Components
+export * from './kanban';

--- a/src/webview/src/components/kanban/Column.tsx
+++ b/src/webview/src/components/kanban/Column.tsx
@@ -1,0 +1,103 @@
+import { useDroppable } from '@dnd-kit/core';
+import { Plus } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import type { TaskDto } from '../../types';
+import { TaskCard } from './TaskCard';
+
+interface ColumnProps {
+	status: string;
+	tasks: TaskDto[];
+	isDone?: boolean;
+	onTaskClick?: (task: TaskDto) => void;
+	onAddTask?: (status: string) => void;
+	activeId?: string | null;
+}
+
+/**
+ * カラムコンポーネント（ステータスごとのタスク一覧）
+ */
+export function Column({ status, tasks, isDone, onTaskClick, onAddTask, activeId }: ColumnProps) {
+	const { isOver, setNodeRef } = useDroppable({
+		id: status,
+		data: { status },
+	});
+
+	const handleAddClick = () => {
+		onAddTask?.(status);
+	};
+
+	return (
+		<div
+			className={cn(
+				'flex flex-col min-w-[280px] max-w-[320px] h-full',
+				'bg-muted/30 rounded-lg border border-border',
+			)}
+		>
+			{/* カラムヘッダー */}
+			<div className="flex items-center justify-between px-4 py-3 border-b border-border">
+				<div className="flex items-center gap-2">
+					<h2
+						className={cn(
+							'text-sm font-semibold uppercase tracking-wide',
+							isDone ? 'text-green-600 dark:text-green-400' : 'text-foreground',
+						)}
+					>
+						{status}
+					</h2>
+					<span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">
+						{tasks.length}
+					</span>
+				</div>
+			</div>
+
+			{/* タスクリスト */}
+			<div
+				ref={setNodeRef}
+				className={cn(
+					'flex-1 p-2 overflow-y-auto space-y-2',
+					'transition-colors duration-200',
+					isOver && 'bg-primary/10 ring-2 ring-primary ring-inset',
+				)}
+			>
+				{tasks.map((task) => (
+					<TaskCard
+						key={task.id}
+						task={task}
+						onClick={onTaskClick}
+						isDragging={activeId === task.id}
+					/>
+				))}
+
+				{/* 空状態 */}
+				{tasks.length === 0 && !isOver && (
+					<div className="flex items-center justify-center h-20 text-muted-foreground text-sm">
+						No tasks
+					</div>
+				)}
+
+				{/* ドロップインジケーター */}
+				{isOver && (
+					<div className="h-16 border-2 border-dashed border-primary rounded-lg bg-primary/5" />
+				)}
+			</div>
+
+			{/* 追加ボタン */}
+			<div className="p-2 border-t border-border">
+				<button
+					type="button"
+					onClick={handleAddClick}
+					className={cn(
+						'w-full flex items-center justify-center gap-2',
+						'px-3 py-2 rounded-md',
+						'text-sm text-muted-foreground',
+						'hover:bg-muted hover:text-foreground',
+						'transition-colors duration-200',
+					)}
+				>
+					<Plus className="h-4 w-4" />
+					Add task
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/webview/src/components/kanban/KanbanBoard.tsx
+++ b/src/webview/src/components/kanban/KanbanBoard.tsx
@@ -1,0 +1,214 @@
+import {
+	DndContext,
+	type DragEndEvent,
+	DragOverlay,
+	type DragStartEvent,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core';
+import { AlertCircle, Loader2, RefreshCw } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useKanban } from '../../hooks/useVscodeApi';
+import { cn } from '../../lib/utils';
+import type { TaskDto, TaskMetadata } from '../../types';
+import { Column } from './Column';
+import { TaskCardOverlay } from './TaskCard';
+import { TaskModal } from './TaskModal';
+
+interface ModalState {
+	isOpen: boolean;
+	task: TaskDto | null;
+	defaultStatus: string | null;
+}
+
+/**
+ * カンバンボードコンポーネント
+ */
+export function KanbanBoard() {
+	const { tasksByStatus, config, paths, isLoading, error, actions } = useKanban();
+
+	const [activeId, setActiveId] = useState<string | null>(null);
+	const [activeTask, setActiveTask] = useState<TaskDto | null>(null);
+	const [modal, setModal] = useState<ModalState>({
+		isOpen: false,
+		task: null,
+		defaultStatus: null,
+	});
+
+	// ドラッグセンサー設定
+	const sensors = useSensors(
+		useSensor(PointerSensor, {
+			activationConstraint: {
+				distance: 8,
+			},
+		}),
+	);
+
+	// ドラッグ開始
+	const handleDragStart = useCallback((event: DragStartEvent) => {
+		const { active } = event;
+		setActiveId(active.id as string);
+		setActiveTask(active.data.current?.task ?? null);
+	}, []);
+
+	// ドラッグ終了（ステータス変更）
+	const handleDragEnd = useCallback(
+		(event: DragEndEvent) => {
+			const { active, over } = event;
+
+			setActiveId(null);
+			setActiveTask(null);
+
+			if (!over) return;
+
+			const taskId = active.id as string;
+			const newStatus = over.id as string;
+			const task = active.data.current?.task as TaskDto | undefined;
+
+			// ステータスが変わった場合のみ更新
+			if (task && task.status !== newStatus) {
+				actions.changeTaskStatus(taskId, newStatus);
+			}
+		},
+		[actions],
+	);
+
+	// タスクカードクリック（編集モーダルを開く）
+	const handleTaskClick = useCallback((task: TaskDto) => {
+		setModal({
+			isOpen: true,
+			task,
+			defaultStatus: null,
+		});
+	}, []);
+
+	// 追加ボタンクリック（新規作成モーダルを開く）
+	const handleAddTask = useCallback((status: string) => {
+		setModal({
+			isOpen: true,
+			task: null,
+			defaultStatus: status,
+		});
+	}, []);
+
+	// モーダルを閉じる
+	const handleCloseModal = useCallback(() => {
+		setModal({
+			isOpen: false,
+			task: null,
+			defaultStatus: null,
+		});
+	}, []);
+
+	// タスクを保存
+	const handleSaveTask = useCallback(
+		(data: { title: string; status: string; path: string[]; metadata?: TaskMetadata }) => {
+			if (modal.task) {
+				// 編集
+				actions.updateTask({
+					id: modal.task.id,
+					title: data.title,
+					path: data.path,
+					metadata: data.metadata,
+				});
+				// ステータスが変わった場合
+				if (modal.task.status !== data.status) {
+					actions.changeTaskStatus(modal.task.id, data.status);
+				}
+			} else {
+				// 新規作成
+				actions.createTask({
+					title: data.title,
+					path: data.path,
+					status: data.status,
+					metadata: data.metadata,
+				});
+			}
+		},
+		[modal.task, actions],
+	);
+
+	// タスクを削除
+	const handleDeleteTask = useCallback(
+		(id: string) => {
+			actions.deleteTask(id);
+		},
+		[actions],
+	);
+
+	// ローディング表示
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center h-full">
+				<div className="flex flex-col items-center gap-4 text-muted-foreground">
+					<Loader2 className="h-8 w-8 animate-spin" />
+					<p className="text-sm">Loading tasks...</p>
+				</div>
+			</div>
+		);
+	}
+
+	// エラー表示
+	if (error) {
+		return (
+			<div className="flex items-center justify-center h-full">
+				<div className="flex flex-col items-center gap-4 text-destructive">
+					<AlertCircle className="h-8 w-8" />
+					<p className="text-sm">{error}</p>
+					<button
+						type="button"
+						onClick={() => {
+							actions.clearError();
+							actions.refreshTasks();
+						}}
+						className={cn(
+							'flex items-center gap-2 px-4 py-2 rounded-md',
+							'text-sm font-medium',
+							'bg-primary text-primary-foreground',
+							'hover:bg-primary/90 transition-colors',
+						)}
+					>
+						<RefreshCw className="h-4 w-4" />
+						Retry
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+				<div className="flex gap-4 p-4 h-full overflow-x-auto">
+					{config.statuses.map((status) => (
+						<Column
+							key={status}
+							status={status}
+							tasks={tasksByStatus[status] ?? []}
+							isDone={config.doneStatuses.includes(status)}
+							onTaskClick={handleTaskClick}
+							onAddTask={handleAddTask}
+							activeId={activeId}
+						/>
+					))}
+				</div>
+
+				{/* ドラッグオーバーレイ */}
+				<DragOverlay>{activeTask && <TaskCardOverlay task={activeTask} />}</DragOverlay>
+			</DndContext>
+
+			{/* タスクモーダル */}
+			<TaskModal
+				isOpen={modal.isOpen}
+				task={modal.task}
+				defaultStatus={modal.defaultStatus ?? config.defaultStatus}
+				statuses={config.statuses}
+				paths={paths}
+				onClose={handleCloseModal}
+				onSave={handleSaveTask}
+				onDelete={modal.task ? handleDeleteTask : undefined}
+			/>
+		</>
+	);
+}

--- a/src/webview/src/components/kanban/PathBadge.tsx
+++ b/src/webview/src/components/kanban/PathBadge.tsx
@@ -1,0 +1,31 @@
+import { cn } from '../../lib/utils';
+
+interface PathBadgeProps {
+	path: string[];
+	className?: string;
+}
+
+/**
+ * パスをバッジとして表示するコンポーネント
+ */
+export function PathBadge({ path, className }: PathBadgeProps) {
+	if (path.length === 0) {
+		return null;
+	}
+
+	const pathString = path.join(' / ');
+
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
+				'bg-muted text-muted-foreground',
+				'truncate max-w-full',
+				className,
+			)}
+			title={pathString}
+		>
+			{pathString}
+		</span>
+	);
+}

--- a/src/webview/src/components/kanban/TaskCard.tsx
+++ b/src/webview/src/components/kanban/TaskCard.tsx
@@ -1,0 +1,106 @@
+import { useDraggable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import type { TaskDto } from '../../types';
+import { PathBadge } from './PathBadge';
+
+interface TaskCardProps {
+	task: TaskDto;
+	onClick?: (task: TaskDto) => void;
+	isDragging?: boolean;
+}
+
+/**
+ * タスクカードコンポーネント
+ */
+export function TaskCard({ task, onClick, isDragging }: TaskCardProps) {
+	const { attributes, listeners, setNodeRef, transform } = useDraggable({
+		id: task.id,
+		data: { task },
+	});
+
+	const style = {
+		transform: CSS.Translate.toString(transform),
+	};
+
+	const handleClick = () => {
+		onClick?.(task);
+	};
+
+	return (
+		<button
+			ref={setNodeRef}
+			type="button"
+			style={style}
+			className={cn(
+				'group relative w-full text-left bg-card border border-border rounded-lg p-3 shadow-sm',
+				'hover:shadow-md hover:border-primary/50 transition-all duration-200',
+				'cursor-pointer select-none',
+				isDragging && 'opacity-50 shadow-lg ring-2 ring-primary',
+			)}
+			onClick={handleClick}
+		>
+			{/* ドラッグハンドル */}
+			<span
+				{...attributes}
+				{...listeners}
+				className={cn(
+					'absolute left-1 top-1/2 -translate-y-1/2 p-1',
+					'opacity-0 group-hover:opacity-100 transition-opacity',
+					'cursor-grab active:cursor-grabbing',
+					'text-muted-foreground hover:text-foreground',
+				)}
+				onPointerDown={(e) => {
+					e.stopPropagation();
+					listeners?.onPointerDown?.(e);
+				}}
+			>
+				<GripVertical className="h-4 w-4" />
+			</span>
+
+			{/* タスク内容 */}
+			<span className="block pl-4">
+				{/* タイトル */}
+				<span
+					className={cn(
+						'block text-sm font-medium text-foreground break-words',
+						task.isChecked && 'line-through text-muted-foreground',
+					)}
+				>
+					{task.title}
+				</span>
+
+				{/* パスバッジ */}
+				{task.path.length > 0 && (
+					<span className="block mt-2">
+						<PathBadge path={task.path} />
+					</span>
+				)}
+			</span>
+		</button>
+	);
+}
+
+/**
+ * ドラッグ中のオーバーレイ用タスクカード
+ */
+export function TaskCardOverlay({ task }: { task: TaskDto }) {
+	return (
+		<div
+			className={cn(
+				'bg-card border border-primary rounded-lg p-3 shadow-xl',
+				'cursor-grabbing rotate-3 scale-105',
+			)}
+		>
+			<div className="pl-4">
+				<p className="text-sm font-medium text-foreground break-words">{task.title}</p>
+				{task.path.length > 0 && (
+					<div className="mt-2">
+						<PathBadge path={task.path} />
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/webview/src/components/kanban/TaskModal.tsx
+++ b/src/webview/src/components/kanban/TaskModal.tsx
@@ -1,0 +1,255 @@
+import { Trash2, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '../../lib/utils';
+import type { TaskDto, TaskMetadata } from '../../types';
+
+interface TaskModalProps {
+	isOpen: boolean;
+	task?: TaskDto | null;
+	defaultStatus?: string;
+	statuses: string[];
+	paths: string[][];
+	onClose: () => void;
+	onSave: (data: {
+		title: string;
+		status: string;
+		path: string[];
+		metadata?: TaskMetadata;
+	}) => void;
+	onDelete?: (id: string) => void;
+}
+
+/**
+ * タスク作成・編集モーダル
+ */
+export function TaskModal({
+	isOpen,
+	task,
+	defaultStatus,
+	statuses,
+	paths,
+	onClose,
+	onSave,
+	onDelete,
+}: TaskModalProps) {
+	const [title, setTitle] = useState('');
+	const [status, setStatus] = useState(defaultStatus ?? statuses[0] ?? 'todo');
+	const [selectedPath, setSelectedPath] = useState<string>('');
+	const titleInputRef = useRef<HTMLInputElement>(null);
+
+	const isEditMode = !!task;
+
+	// パス選択肢を準備
+	const pathOptions = [
+		{ value: '', label: '(root)' },
+		...paths
+			.filter((p) => p.length > 0)
+			.map((p) => ({
+				value: p.join(' / '),
+				label: p.join(' / '),
+			})),
+	];
+
+	// タスクデータで初期化
+	useEffect(() => {
+		if (isOpen) {
+			if (task) {
+				setTitle(task.title);
+				setStatus(task.status);
+				setSelectedPath(task.path.join(' / '));
+			} else {
+				setTitle('');
+				setStatus(defaultStatus ?? statuses[0] ?? 'todo');
+				setSelectedPath('');
+			}
+			// フォーカス
+			setTimeout(() => titleInputRef.current?.focus(), 100);
+		}
+	}, [isOpen, task, defaultStatus, statuses]);
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!title.trim()) return;
+
+		const path = selectedPath ? selectedPath.split(' / ') : [];
+		onSave({
+			title: title.trim(),
+			status,
+			path,
+		});
+		onClose();
+	};
+
+	const handleDelete = () => {
+		if (task && onDelete) {
+			onDelete(task.id);
+			onClose();
+		}
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			onClose();
+		}
+	};
+
+	if (!isOpen) return null;
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: Modal wrapper needs keyboard handler
+		<div className="fixed inset-0 z-50 flex items-center justify-center" onKeyDown={handleKeyDown}>
+			{/* オーバーレイ */}
+			<button
+				type="button"
+				className="absolute inset-0 bg-black/50 cursor-default"
+				onClick={onClose}
+				aria-label="Close modal"
+			/>
+
+			{/* モーダル */}
+			<div
+				className={cn(
+					'relative z-10 w-full max-w-md mx-4',
+					'bg-card border border-border rounded-lg shadow-xl',
+				)}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="modal-title"
+			>
+				{/* ヘッダー */}
+				<div className="flex items-center justify-between px-4 py-3 border-b border-border">
+					<h2 id="modal-title" className="text-lg font-semibold text-foreground">
+						{isEditMode ? 'Edit Task' : 'New Task'}
+					</h2>
+					<button
+						type="button"
+						onClick={onClose}
+						className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+					>
+						<X className="h-5 w-5" />
+					</button>
+				</div>
+
+				{/* フォーム */}
+				<form onSubmit={handleSubmit} className="p-4 space-y-4">
+					{/* タイトル */}
+					<div className="space-y-2">
+						<label htmlFor="title" className="block text-sm font-medium text-foreground">
+							Title
+						</label>
+						<input
+							ref={titleInputRef}
+							id="title"
+							type="text"
+							value={title}
+							onChange={(e) => setTitle(e.target.value)}
+							placeholder="Enter task title..."
+							className={cn(
+								'w-full px-3 py-2 rounded-md',
+								'bg-background border border-input',
+								'text-foreground placeholder:text-muted-foreground',
+								'focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent',
+							)}
+							required
+						/>
+					</div>
+
+					{/* ステータス */}
+					<div className="space-y-2">
+						<label htmlFor="status" className="block text-sm font-medium text-foreground">
+							Status
+						</label>
+						<select
+							id="status"
+							value={status}
+							onChange={(e) => setStatus(e.target.value)}
+							className={cn(
+								'w-full px-3 py-2 rounded-md',
+								'bg-background border border-input',
+								'text-foreground',
+								'focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent',
+							)}
+						>
+							{statuses.map((s) => (
+								<option key={s} value={s}>
+									{s}
+								</option>
+							))}
+						</select>
+					</div>
+
+					{/* パス */}
+					<div className="space-y-2">
+						<label htmlFor="path" className="block text-sm font-medium text-foreground">
+							Path
+						</label>
+						<select
+							id="path"
+							value={selectedPath}
+							onChange={(e) => setSelectedPath(e.target.value)}
+							className={cn(
+								'w-full px-3 py-2 rounded-md',
+								'bg-background border border-input',
+								'text-foreground',
+								'focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent',
+							)}
+						>
+							{pathOptions.map((opt) => (
+								<option key={opt.value} value={opt.value}>
+									{opt.label}
+								</option>
+							))}
+						</select>
+					</div>
+
+					{/* アクションボタン */}
+					<div className="flex items-center justify-between pt-4">
+						{/* 削除ボタン（編集モードのみ） */}
+						<div>
+							{isEditMode && onDelete && (
+								<button
+									type="button"
+									onClick={handleDelete}
+									className={cn(
+										'flex items-center gap-2 px-3 py-2 rounded-md',
+										'text-sm text-destructive',
+										'hover:bg-destructive/10 transition-colors',
+									)}
+								>
+									<Trash2 className="h-4 w-4" />
+									Delete
+								</button>
+							)}
+						</div>
+
+						{/* 保存・キャンセルボタン */}
+						<div className="flex items-center gap-2">
+							<button
+								type="button"
+								onClick={onClose}
+								className={cn(
+									'px-4 py-2 rounded-md',
+									'text-sm text-muted-foreground',
+									'hover:bg-muted transition-colors',
+								)}
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								className={cn(
+									'px-4 py-2 rounded-md',
+									'text-sm font-medium',
+									'bg-primary text-primary-foreground',
+									'hover:bg-primary/90 transition-colors',
+								)}
+							>
+								{isEditMode ? 'Save' : 'Create'}
+							</button>
+						</div>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/src/webview/src/components/kanban/index.ts
+++ b/src/webview/src/components/kanban/index.ts
@@ -1,0 +1,5 @@
+export { Column } from './Column';
+export { KanbanBoard } from './KanbanBoard';
+export { PathBadge } from './PathBadge';
+export { TaskCard, TaskCardOverlay } from './TaskCard';
+export { TaskModal } from './TaskModal';

--- a/src/webview/src/hooks/index.ts
+++ b/src/webview/src/hooks/index.ts
@@ -1,2 +1,6 @@
-export type { VscodeMessage } from './useVscodeApi';
-export { useVscodeApi, useVscodeMessage, useVscodeMessages } from './useVscodeApi';
+export {
+	useKanban,
+	useVscodeApi,
+	useVscodeMessage,
+	useVscodeMessages,
+} from './useVscodeApi';

--- a/src/webview/src/types/index.ts
+++ b/src/webview/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './messages';

--- a/src/webview/src/types/messages.ts
+++ b/src/webview/src/types/messages.ts
@@ -1,0 +1,201 @@
+/**
+ * WebView側のメッセージ型定義
+ * Extension側の型定義と同期を維持すること
+ */
+
+/**
+ * タスクメタデータ
+ */
+export interface TaskMetadata {
+	priority?: string;
+	due?: string;
+	assignee?: string;
+	tags?: string[];
+	[key: string]: unknown;
+}
+
+/**
+ * タスクDTO（Extension ⇔ WebView間の通信用）
+ */
+export interface TaskDto {
+	id: string;
+	title: string;
+	status: string;
+	path: string[];
+	isChecked: boolean;
+	metadata: TaskMetadata;
+}
+
+/**
+ * カンバン設定
+ */
+export interface KanbanConfig {
+	statuses: string[];
+	doneStatuses: string[];
+	defaultStatus: string;
+	defaultDoneStatus: string;
+	sortBy: 'markdown' | 'priority' | 'due' | 'alphabetical';
+	syncCheckboxWithDone: boolean;
+}
+
+// =============================================================================
+// WebView → Extension メッセージ
+// =============================================================================
+
+/**
+ * タスク一覧取得リクエスト
+ */
+export interface GetTasksRequest {
+	type: 'GET_TASKS';
+}
+
+/**
+ * タスク作成リクエスト
+ */
+export interface CreateTaskRequest {
+	type: 'CREATE_TASK';
+	payload: {
+		title: string;
+		path: string[];
+		status?: string;
+		metadata?: TaskMetadata;
+	};
+}
+
+/**
+ * タスク更新リクエスト
+ */
+export interface UpdateTaskRequest {
+	type: 'UPDATE_TASK';
+	payload: {
+		id: string;
+		title?: string;
+		path?: string[];
+		metadata?: TaskMetadata;
+	};
+}
+
+/**
+ * タスク削除リクエスト
+ */
+export interface DeleteTaskRequest {
+	type: 'DELETE_TASK';
+	payload: {
+		id: string;
+	};
+}
+
+/**
+ * タスクステータス変更リクエスト
+ */
+export interface ChangeTaskStatusRequest {
+	type: 'CHANGE_TASK_STATUS';
+	payload: {
+		id: string;
+		status: string;
+	};
+}
+
+/**
+ * 設定取得リクエスト
+ */
+export interface GetConfigRequest {
+	type: 'GET_CONFIG';
+}
+
+/**
+ * WebView → Extension の全メッセージタイプ
+ */
+export type WebViewToExtensionMessage =
+	| GetTasksRequest
+	| CreateTaskRequest
+	| UpdateTaskRequest
+	| DeleteTaskRequest
+	| ChangeTaskStatusRequest
+	| GetConfigRequest;
+
+// =============================================================================
+// Extension → WebView メッセージ
+// =============================================================================
+
+/**
+ * タスク一覧更新メッセージ
+ */
+export interface TasksUpdatedMessage {
+	type: 'TASKS_UPDATED';
+	payload: {
+		tasks: TaskDto[];
+	};
+}
+
+/**
+ * タスク作成成功メッセージ
+ */
+export interface TaskCreatedMessage {
+	type: 'TASK_CREATED';
+	payload: {
+		task: TaskDto;
+	};
+}
+
+/**
+ * タスク更新成功メッセージ
+ */
+export interface TaskUpdatedMessage {
+	type: 'TASK_UPDATED';
+	payload: {
+		task: TaskDto;
+	};
+}
+
+/**
+ * タスク削除成功メッセージ
+ */
+export interface TaskDeletedMessage {
+	type: 'TASK_DELETED';
+	payload: {
+		id: string;
+	};
+}
+
+/**
+ * 設定更新メッセージ
+ */
+export interface ConfigUpdatedMessage {
+	type: 'CONFIG_UPDATED';
+	payload: {
+		config: KanbanConfig;
+	};
+}
+
+/**
+ * エラーメッセージ
+ */
+export interface ErrorMessage {
+	type: 'ERROR';
+	payload: {
+		message: string;
+		code?: string;
+	};
+}
+
+/**
+ * Extension → WebView の全メッセージタイプ
+ */
+export type ExtensionToWebViewMessage =
+	| TasksUpdatedMessage
+	| TaskCreatedMessage
+	| TaskUpdatedMessage
+	| TaskDeletedMessage
+	| ConfigUpdatedMessage
+	| ErrorMessage;
+
+/**
+ * 全メッセージタイプ
+ */
+export type Message = WebViewToExtensionMessage | ExtensionToWebViewMessage;
+
+/**
+ * メッセージタイプの文字列リテラル
+ */
+export type MessageType = Message['type'];


### PR DESCRIPTION
Phase 7の実装として、カンバンボードUIを構築:

- コンポーネント:
  - KanbanBoard: ボード全体の管理、D&Dコンテキスト
  - Column: ステータスカラム、ドロップターゲット
  - TaskCard: タスクカード、ドラッグ可能
  - TaskModal: タスク作成・編集モーダル
  - PathBadge: パス表示バッジ

- Extension通信:
  - useVscodeApi: 型安全なメッセージ送受信
  - useKanban: カンバン状態管理フック

- ドラッグ&ドロップ:
  - @dnd-kit/coreを使用した列間D&D
  - ステータス変更の自動反映

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fully functional Kanban board with drag-and-drop task management across columns
  * Create, edit, and delete tasks directly from the interface with status change support
  * Task paths displayed for improved organization and context
  * Complete messaging integration between WebView and extension for seamless data synchronization

* **Chores**
  * Added drag-and-drop library dependencies for enhanced user interactions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->