### PR TITLE
fix: WebViewパネル作成時にactiveTextEditorがundefinedになる問題を修正

### DIFF
--- a/packages/core/src/application/usecases/changeTaskStatusUseCase.ts
+++ b/packages/core/src/application/usecases/changeTaskStatusUseCase.ts
@@ -1,5 +1,6 @@
 import type { Result } from 'neverthrow';
 import type { Task } from '../../domain/entities/task';
+import type { NoActiveEditorError } from '../../domain/errors/noActiveEditorError';
 import type { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
 import type { TaskParseError } from '../../domain/errors/taskParseError';
 import type { ConfigProvider } from '../../domain/ports/configProvider';
@@ -21,7 +22,7 @@ export class ChangeTaskStatusUseCase {
 	async execute(
 		id: string,
 		newStatus: Status,
-	): Promise<Result<Task, TaskNotFoundError | TaskParseError>> {
+	): Promise<Result<Task, TaskNotFoundError | TaskParseError | NoActiveEditorError>> {
 		// 設定を取得
 		const config = await this.configProvider.getConfig();
 

--- a/packages/core/src/application/usecases/createTaskUseCase.ts
+++ b/packages/core/src/application/usecases/createTaskUseCase.ts
@@ -1,5 +1,6 @@
 import type { Result } from 'neverthrow';
 import { Task, type TaskMetadata } from '../../domain/entities/task';
+import type { NoActiveEditorError } from '../../domain/errors/noActiveEditorError';
 import type { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
 import type { ConfigProvider } from '../../domain/ports/configProvider';
 import type { TaskRepository } from '../../domain/ports/taskRepository';
@@ -28,7 +29,9 @@ export class CreateTaskUseCase {
 	/**
 	 * 新しいタスクを作成する
 	 */
-	async execute(input: CreateTaskInput): Promise<Result<Task, TaskNotFoundError>> {
+	async execute(
+		input: CreateTaskInput,
+	): Promise<Result<Task, TaskNotFoundError | NoActiveEditorError>> {
 		const config = await this.configProvider.getConfig();
 
 		// ステータスが指定されていない場合はデフォルトステータスを使用

--- a/packages/core/src/application/usecases/deleteTaskUseCase.ts
+++ b/packages/core/src/application/usecases/deleteTaskUseCase.ts
@@ -1,4 +1,5 @@
 import type { Result } from 'neverthrow';
+import type { NoActiveEditorError } from '../../domain/errors/noActiveEditorError';
 import type { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
 import type { TaskRepository } from '../../domain/ports/taskRepository';
 
@@ -11,7 +12,7 @@ export class DeleteTaskUseCase {
 	/**
 	 * タスクを削除する
 	 */
-	async execute(id: string): Promise<Result<void, TaskNotFoundError>> {
+	async execute(id: string): Promise<Result<void, TaskNotFoundError | NoActiveEditorError>> {
 		return this.taskRepository.delete(id);
 	}
 }

--- a/packages/core/src/application/usecases/getTasksUseCase.ts
+++ b/packages/core/src/application/usecases/getTasksUseCase.ts
@@ -1,5 +1,6 @@
 import type { Result } from 'neverthrow';
 import type { Task } from '../../domain/entities/task';
+import type { NoActiveEditorError } from '../../domain/errors/noActiveEditorError';
 import type { TaskParseError } from '../../domain/errors/taskParseError';
 import type { TaskRepository } from '../../domain/ports/taskRepository';
 import type { Path } from '../../domain/valueObjects/path';
@@ -13,14 +14,14 @@ export class GetTasksUseCase {
 	/**
 	 * 全タスクを取得する
 	 */
-	async execute(): Promise<Result<Task[], TaskParseError>> {
+	async execute(): Promise<Result<Task[], TaskParseError | NoActiveEditorError>> {
 		return this.taskRepository.findAll();
 	}
 
 	/**
 	 * 指定したパス配下のタスクを取得する
 	 */
-	async executeByPath(path: Path): Promise<Result<Task[], TaskParseError>> {
+	async executeByPath(path: Path): Promise<Result<Task[], TaskParseError | NoActiveEditorError>> {
 		return this.taskRepository.findByPath(path);
 	}
 }

--- a/packages/core/src/application/usecases/updateTaskUseCase.ts
+++ b/packages/core/src/application/usecases/updateTaskUseCase.ts
@@ -1,5 +1,6 @@
 import type { Result } from 'neverthrow';
 import type { Task, TaskMetadata } from '../../domain/entities/task';
+import type { NoActiveEditorError } from '../../domain/errors/noActiveEditorError';
 import type { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
 import type { TaskParseError } from '../../domain/errors/taskParseError';
 import type { TaskRepository } from '../../domain/ports/taskRepository';
@@ -24,7 +25,9 @@ export class UpdateTaskUseCase {
 	/**
 	 * タスクを更新する
 	 */
-	async execute(input: UpdateTaskInput): Promise<Result<Task, TaskNotFoundError | TaskParseError>> {
+	async execute(
+		input: UpdateTaskInput,
+	): Promise<Result<Task, TaskNotFoundError | TaskParseError | NoActiveEditorError>> {
 		// タスクを取得
 		const findResult = await this.taskRepository.findById(input.id);
 		if (findResult.isErr()) {

--- a/packages/core/src/bootstrap/di/container.ts
+++ b/packages/core/src/bootstrap/di/container.ts
@@ -175,6 +175,13 @@ export class Container {
 	getConfigController(): ConfigController {
 		return this.configController;
 	}
+
+	/**
+	 * VscodeDocumentClientを取得
+	 */
+	getVscodeDocumentClient(): VscodeDocumentClient {
+		return this.vscodeDocumentClient;
+	}
 }
 
 /**

--- a/packages/core/src/domain/errors/index.ts
+++ b/packages/core/src/domain/errors/index.ts
@@ -1,4 +1,5 @@
 // Domain Errors
 export { InvalidStatusError } from './invalidStatusError';
+export { NoActiveEditorError } from './noActiveEditorError';
 export { TaskNotFoundError } from './taskNotFoundError';
 export { TaskParseError } from './taskParseError';

--- a/packages/core/src/domain/errors/noActiveEditorError.ts
+++ b/packages/core/src/domain/errors/noActiveEditorError.ts
@@ -1,0 +1,12 @@
+/**
+ * アクティブなエディタがないエラー
+ * これは正常な状態遷移の一つ（WebViewにフォーカスがある場合など）
+ */
+export class NoActiveEditorError extends Error {
+	readonly _tag = 'NoActiveEditorError';
+
+	constructor(message = 'Markdownファイルを開いてください') {
+		super(message);
+		this.name = 'NoActiveEditorError';
+	}
+}

--- a/packages/core/src/domain/ports/taskRepository.ts
+++ b/packages/core/src/domain/ports/taskRepository.ts
@@ -1,5 +1,6 @@
 import type { Result } from 'neverthrow';
 import type { Task } from '../entities/task';
+import type { NoActiveEditorError } from '../errors/noActiveEditorError';
 import type { TaskNotFoundError } from '../errors/taskNotFoundError';
 import type { TaskParseError } from '../errors/taskParseError';
 import type { Path } from '../valueObjects/path';
@@ -12,30 +13,32 @@ export interface TaskRepository {
 	/**
 	 * 全タスクを取得する
 	 */
-	findAll(): Promise<Result<Task[], TaskParseError>>;
+	findAll(): Promise<Result<Task[], TaskParseError | NoActiveEditorError>>;
 
 	/**
 	 * IDでタスクを取得する
 	 */
-	findById(id: string): Promise<Result<Task, TaskNotFoundError | TaskParseError>>;
+	findById(
+		id: string,
+	): Promise<Result<Task, TaskNotFoundError | TaskParseError | NoActiveEditorError>>;
 
 	/**
 	 * パスでタスクをフィルタリングして取得する
 	 */
-	findByPath(path: Path): Promise<Result<Task[], TaskParseError>>;
+	findByPath(path: Path): Promise<Result<Task[], TaskParseError | NoActiveEditorError>>;
 
 	/**
 	 * タスクを保存する（作成または更新）
 	 */
-	save(task: Task): Promise<Result<Task, TaskNotFoundError>>;
+	save(task: Task): Promise<Result<Task, TaskNotFoundError | NoActiveEditorError>>;
 
 	/**
 	 * タスクを削除する
 	 */
-	delete(id: string): Promise<Result<void, TaskNotFoundError>>;
+	delete(id: string): Promise<Result<void, TaskNotFoundError | NoActiveEditorError>>;
 
 	/**
 	 * 利用可能なパス（見出し階層）を全て取得する
 	 */
-	getAvailablePaths(): Promise<Result<Path[], TaskParseError>>;
+	getAvailablePaths(): Promise<Result<Path[], TaskParseError | NoActiveEditorError>>;
 }

--- a/packages/core/src/infrastructure/adapters/markdownTaskRepository.test.ts
+++ b/packages/core/src/infrastructure/adapters/markdownTaskRepository.test.ts
@@ -38,6 +38,7 @@ const createMockVscodeDocumentClient = (
 ): VscodeDocumentClient =>
 	({
 		getActiveDocumentText: vi.fn().mockReturnValue(ok('# Test')),
+		getCurrentDocumentText: vi.fn().mockResolvedValue(ok('# Test')),
 		replaceDocumentText: vi.fn().mockResolvedValue(ok(undefined)),
 		...overrides,
 	}) as unknown as VscodeDocumentClient;
@@ -104,7 +105,7 @@ describe('MarkdownTaskRepository', () => {
 		it('ドキュメントがない場合はエラーを返す', async () => {
 			const markdownClient = createMockMarkdownTaskClient();
 			const documentClient = createMockVscodeDocumentClient({
-				getActiveDocumentText: vi.fn().mockReturnValue({
+				getCurrentDocumentText: vi.fn().mockResolvedValue({
 					isErr: () => true,
 					isOk: () => false,
 					error: { message: 'No document' },

--- a/packages/core/src/infrastructure/clients/index.ts
+++ b/packages/core/src/infrastructure/clients/index.ts
@@ -16,6 +16,7 @@ export {
 	DocumentEditError,
 	type DocumentInfo,
 	DocumentNotFoundError,
+	NoActiveEditorError,
 	VscodeDocumentClient,
 	type VscodeDocumentDeps,
 } from './vscodeDocumentClient';

--- a/packages/core/src/infrastructure/clients/vscodeDocumentClient.test.ts
+++ b/packages/core/src/infrastructure/clients/vscodeDocumentClient.test.ts
@@ -3,6 +3,7 @@ import type * as vscode from 'vscode';
 import {
 	DocumentEditError,
 	DocumentNotFoundError,
+	NoActiveEditorError,
 	VscodeDocumentClient,
 	type VscodeDocumentDeps,
 } from './vscodeDocumentClient';
@@ -46,7 +47,7 @@ describe('VscodeDocumentClient', () => {
 
 			expect(result.isErr()).toBe(true);
 			if (result.isErr()) {
-				expect(result.error).toBeInstanceOf(DocumentNotFoundError);
+				expect(result.error).toBeInstanceOf(NoActiveEditorError);
 				expect(result.error.message).toBe('アクティブなエディタがありません');
 			}
 		});
@@ -166,7 +167,7 @@ describe('VscodeDocumentClient', () => {
 
 			expect(result.isErr()).toBe(true);
 			if (result.isErr()) {
-				expect(result.error).toBeInstanceOf(DocumentNotFoundError);
+				expect(result.error).toBeInstanceOf(NoActiveEditorError);
 			}
 		});
 

--- a/packages/core/src/infrastructure/clients/vscodeDocumentClient.ts
+++ b/packages/core/src/infrastructure/clients/vscodeDocumentClient.ts
@@ -13,6 +13,18 @@ export class DocumentNotFoundError extends Error {
 }
 
 /**
+ * アクティブなエディタがないエラー
+ * これは正常な状態遷移の一つ（WebViewにフォーカスがある場合など）
+ */
+export class NoActiveEditorError extends Error {
+	readonly _tag = 'NoActiveEditorError';
+	constructor(message = 'アクティブなエディタがありません') {
+		super(message);
+		this.name = 'NoActiveEditorError';
+	}
+}
+
+/**
  * ドキュメント編集エラー
  */
 export class DocumentEditError extends Error {
@@ -55,15 +67,32 @@ export interface DocumentInfo {
  * VSCodeのテキストドキュメント操作のラッパー
  */
 export class VscodeDocumentClient {
+	private currentDocumentUri: vscode.Uri | undefined;
+
 	constructor(private readonly deps: VscodeDocumentDeps) {}
+
+	/**
+	 * 現在のドキュメントURIを設定する
+	 * WebViewパネル作成時やエディタ切り替え時に呼び出される
+	 */
+	setCurrentDocumentUri(uri: vscode.Uri | undefined): void {
+		this.currentDocumentUri = uri;
+	}
+
+	/**
+	 * 現在のドキュメントURIを取得する
+	 */
+	getCurrentDocumentUri(): vscode.Uri | undefined {
+		return this.currentDocumentUri;
+	}
 
 	/**
 	 * アクティブなドキュメントの情報を取得する
 	 */
-	getActiveDocument(): Result<DocumentInfo, DocumentNotFoundError> {
+	getActiveDocument(): Result<DocumentInfo, NoActiveEditorError> {
 		const editor = this.deps.getActiveTextEditor();
 		if (!editor) {
-			return err(new DocumentNotFoundError('アクティブなエディタがありません'));
+			return err(new NoActiveEditorError());
 		}
 
 		const document = editor.document;
@@ -78,7 +107,7 @@ export class VscodeDocumentClient {
 	/**
 	 * アクティブなドキュメントのテキストを取得する
 	 */
-	getActiveDocumentText(): Result<string, DocumentNotFoundError> {
+	getActiveDocumentText(): Result<string, NoActiveEditorError> {
 		const result = this.getActiveDocument();
 		return result.map((doc) => doc.text);
 	}
@@ -86,42 +115,79 @@ export class VscodeDocumentClient {
 	/**
 	 * アクティブなドキュメントのURIを取得する
 	 */
-	getActiveDocumentUri(): Result<vscode.Uri, DocumentNotFoundError> {
+	getActiveDocumentUri(): Result<vscode.Uri, NoActiveEditorError> {
 		const result = this.getActiveDocument();
 		return result.map((doc) => doc.uri);
 	}
 
 	/**
-	 * アクティブなドキュメントのテキストを置換する
+	 * 現在のドキュメントのテキストを取得する
+	 * currentDocumentUriがセットされている場合はそれを使用し、
+	 * なければactiveTextEditorから取得する
+	 */
+	async getCurrentDocumentText(): Promise<
+		Result<string, NoActiveEditorError | DocumentNotFoundError>
+	> {
+		// currentDocumentUriがセットされている場合はそれを使用
+		if (this.currentDocumentUri) {
+			return this.openAndGetText(this.currentDocumentUri);
+		}
+
+		// フォールバック: activeTextEditorから取得
+		return this.getActiveDocumentText();
+	}
+
+	/**
+	 * 現在のドキュメントのURIを取得する
+	 * currentDocumentUriがセットされている場合はそれを使用し、
+	 * なければactiveTextEditorから取得する
+	 */
+	getCurrentDocumentUriOrActive(): Result<vscode.Uri, NoActiveEditorError> {
+		if (this.currentDocumentUri) {
+			return ok(this.currentDocumentUri);
+		}
+		return this.getActiveDocumentUri();
+	}
+
+	/**
+	 * 現在のドキュメントのテキストを置換する
+	 * currentDocumentUriがセットされている場合はそれを使用し、
+	 * なければactiveTextEditorから取得する
 	 */
 	async replaceDocumentText(
 		newText: string,
-	): Promise<Result<void, DocumentNotFoundError | DocumentEditError>> {
-		const uriResult = this.getActiveDocumentUri();
+	): Promise<Result<void, NoActiveEditorError | DocumentNotFoundError | DocumentEditError>> {
+		// URIを取得
+		const uriResult = this.getCurrentDocumentUriOrActive();
 		if (uriResult.isErr()) {
 			return err(uriResult.error);
 		}
-
 		const uri = uriResult.value;
-		const docResult = this.getActiveDocument();
-		if (docResult.isErr()) {
-			return err(docResult.error);
+
+		// ドキュメントを開いてテキストと行数を取得
+		try {
+			const document = await this.deps.openTextDocument(uri);
+			const lineCount = document.lineCount;
+			const lastLine = lineCount > 0 ? lineCount - 1 : 0;
+			const lastLineText = document.getText().split('\n')[lastLine] ?? '';
+
+			const edit = this.deps.createWorkspaceEdit();
+			const fullRange = this.deps.createRange(0, 0, lastLine, lastLineText.length);
+			edit.replace(uri, fullRange, newText);
+
+			const success = await this.deps.applyEdit(edit);
+			if (!success) {
+				return err(new DocumentEditError('ドキュメントの編集に失敗しました'));
+			}
+
+			return ok(undefined);
+		} catch (error) {
+			return err(
+				new DocumentNotFoundError(
+					`ドキュメントを開けませんでした: ${error instanceof Error ? error.message : String(error)}`,
+				),
+			);
 		}
-
-		const lineCount = docResult.value.lineCount;
-		const lastLine = lineCount > 0 ? lineCount - 1 : 0;
-		const lastLineText = docResult.value.text.split('\n')[lastLine] ?? '';
-
-		const edit = this.deps.createWorkspaceEdit();
-		const fullRange = this.deps.createRange(0, 0, lastLine, lastLineText.length);
-		edit.replace(uri, fullRange, newText);
-
-		const success = await this.deps.applyEdit(edit);
-		if (!success) {
-			return err(new DocumentEditError('ドキュメントの編集に失敗しました'));
-		}
-
-		return ok(undefined);
 	}
 
 	/**

--- a/packages/core/src/interface/adapters/webViewMessageHandler.ts
+++ b/packages/core/src/interface/adapters/webViewMessageHandler.ts
@@ -142,7 +142,12 @@ export class WebViewMessageHandler {
 	 * エラーを送信する
 	 */
 	private sendError(error: Error & { _tag?: string }): void {
-		logger.error(`Error: ${error.message}`, { errorType: error._tag, message: error.message });
+		// NoActiveEditorErrorは正常な状態遷移の一つなのでdebugレベルでログ出力
+		if (error._tag === 'NoActiveEditorError') {
+			logger.debug(`No active editor: ${error.message}`);
+		} else {
+			logger.error(`Error: ${error.message}`, { errorType: error._tag, message: error.message });
+		}
 		this.messageClient.sendError(error.message, error._tag);
 	}
 }

--- a/packages/webview/src/hooks/useVscodeApi.ts
+++ b/packages/webview/src/hooks/useVscodeApi.ts
@@ -190,12 +190,21 @@ export function useKanban() {
 					tasks: prev.tasks.filter((t) => t.id !== payload.id),
 				}));
 			},
-			ERROR: (payload: { message: string }) => {
-				setState((prev) => ({
-					...prev,
-					error: payload.message,
-					isLoading: false,
-				}));
+			ERROR: (payload: { message: string; code?: string }) => {
+				// NoActiveEditorErrorは正常な状態遷移なのでエラーとして扱わない
+				if (payload.code === 'NoActiveEditorError') {
+					setState((prev) => ({
+						...prev,
+						error: 'Markdownファイルを開いてください',
+						isLoading: false,
+					}));
+				} else {
+					setState((prev) => ({
+						...prev,
+						error: payload.message,
+						isLoading: false,
+					}));
+				}
 			},
 		}),
 		[],


### PR DESCRIPTION
## Summary

- WebViewパネル作成時に`activeTextEditor`が`undefined`になりタスク取得に失敗する問題を修正
- パネル作成前にMarkdownファイルのURIを保存し、それを使ってドキュメントを取得する方式に変更
- `NoActiveEditorError`を追加し、正常な状態遷移としてログレベルを調整

## 変更内容

### 根本原因の解決（URI保存方式）
- `VscodeDocumentClient`に`currentDocumentUri`フィールドを追加
- `KanbanPanelProvider`でパネル作成前にURIを保存、エディタ切り替え時に更新
- `getCurrentDocumentText()`でURIがあればそれを使用

### エラー型の適切な分類
- ドメイン層に`NoActiveEditorError`を追加
- `TaskRepository`インターフェースのエラー型を更新

### ユーザー体験の改善
- `NoActiveEditorError`の場合は`logger.debug`でログ出力（ERRORではなく）
- WebView側で「Markdownファイルを開いてください」メッセージを表示

## Test plan

- [x] すべての既存テスト（225件）が通ること
- [x] ビルドが成功すること
- [ ] Markdownファイルを開いた状態でカンバンボタンをクリックしてパネルを開く
- [ ] パネルにタスクが正常に表示されること
- [ ] エラーログが出力されないこと

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced improved error handling when no Markdown file is open, with clearer user-facing messages.
  * Enhanced document tracking to better manage which Markdown file is currently being edited.

* **Bug Fixes**
  * Fixed document state management to properly track active files during editing sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->