### PR TITLE
fix: updateTaskでステータス更新を一括処理して競合状態を解消

### DIFF
--- a/packages/core/src/application/usecases/updateTaskUseCase.ts
+++ b/packages/core/src/application/usecases/updateTaskUseCase.ts
@@ -1,10 +1,13 @@
-import type { Result } from 'neverthrow';
+import { err, type Result } from 'neverthrow';
 import type { Task, TaskMetadata } from '../../domain/entities/task';
+import type { InvalidStatusError } from '../../domain/errors/invalidStatusError';
 import type { NoActiveEditorError } from '../../domain/errors/noActiveEditorError';
 import type { TaskNotFoundError } from '../../domain/errors/taskNotFoundError';
 import type { TaskParseError } from '../../domain/errors/taskParseError';
+import type { ConfigProvider } from '../../domain/ports/configProvider';
 import type { TaskRepository } from '../../domain/ports/taskRepository';
 import type { Path } from '../../domain/valueObjects/path';
+import { Status } from '../../domain/valueObjects/status';
 
 /**
  * タスク更新の入力
@@ -13,6 +16,7 @@ export interface UpdateTaskInput {
 	id: string;
 	title?: string;
 	path?: Path;
+	status?: string;
 	metadata?: TaskMetadata;
 }
 
@@ -20,14 +24,19 @@ export interface UpdateTaskInput {
  * タスク更新ユースケース
  */
 export class UpdateTaskUseCase {
-	constructor(private readonly taskRepository: TaskRepository) {}
+	constructor(
+		private readonly taskRepository: TaskRepository,
+		private readonly configProvider: ConfigProvider,
+	) {}
 
 	/**
 	 * タスクを更新する
 	 */
 	async execute(
 		input: UpdateTaskInput,
-	): Promise<Result<Task, TaskNotFoundError | TaskParseError | NoActiveEditorError>> {
+	): Promise<
+		Result<Task, TaskNotFoundError | TaskParseError | NoActiveEditorError | InvalidStatusError>
+	> {
 		// タスクを取得
 		const findResult = await this.taskRepository.findById(input.id);
 		if (findResult.isErr()) {
@@ -44,6 +53,19 @@ export class UpdateTaskUseCase {
 		// パスを更新
 		if (input.path !== undefined) {
 			task = task.updatePath(input.path);
+		}
+
+		// ステータスを更新
+		if (input.status !== undefined) {
+			const statusResult = Status.create(input.status);
+			if (statusResult.isErr()) {
+				return err(statusResult.error);
+			}
+
+			// 設定を取得（チェックボックス連動の判定用）
+			const config = await this.configProvider.getConfig();
+			const doneStatuses = config.syncCheckboxWithDone ? config.doneStatuses : undefined;
+			task = task.updateStatus(statusResult.value, doneStatuses);
 		}
 
 		// メタデータを更新

--- a/packages/core/src/bootstrap/di/container.ts
+++ b/packages/core/src/bootstrap/di/container.ts
@@ -121,7 +121,10 @@ export class Container {
 		);
 
 		// UpdateTaskUseCase
-		this.updateTaskUseCase = new UpdateTaskUseCase(this.markdownTaskRepository);
+		this.updateTaskUseCase = new UpdateTaskUseCase(
+			this.markdownTaskRepository,
+			this.frontmatterConfigProvider,
+		);
 
 		// DeleteTaskUseCase
 		this.deleteTaskUseCase = new DeleteTaskUseCase(this.markdownTaskRepository);

--- a/packages/core/src/interface/adapters/taskController.ts
+++ b/packages/core/src/interface/adapters/taskController.ts
@@ -34,6 +34,7 @@ export interface UpdateTaskDto {
 	id: string;
 	title?: string;
 	path?: string[];
+	status?: string;
 	metadata?: TaskMetadata;
 }
 
@@ -90,11 +91,14 @@ export class TaskController {
 	 */
 	async updateTask(
 		dto: UpdateTaskDto,
-	): Promise<Result<TaskDto, TaskNotFoundError | TaskParseError | NoActiveEditorError>> {
+	): Promise<
+		Result<TaskDto, TaskNotFoundError | TaskParseError | InvalidStatusError | NoActiveEditorError>
+	> {
 		const input: UpdateTaskInput = {
 			id: dto.id,
 			title: dto.title,
 			path: dto.path ? Path.create(dto.path) : undefined,
+			status: dto.status,
 			metadata: dto.metadata,
 		};
 

--- a/packages/core/src/interface/adapters/webViewMessageHandler.ts
+++ b/packages/core/src/interface/adapters/webViewMessageHandler.ts
@@ -88,12 +88,14 @@ export class WebViewMessageHandler {
 		id: string;
 		title?: string;
 		path?: string[];
+		status?: string;
 		metadata?: Record<string, string>;
 	}): Promise<void> {
 		const result = await this.taskController.updateTask({
 			id: payload.id,
 			title: payload.title,
 			path: payload.path,
+			status: payload.status,
 			metadata: payload.metadata,
 		});
 

--- a/packages/core/src/interface/types/messages.ts
+++ b/packages/core/src/interface/types/messages.ts
@@ -46,6 +46,7 @@ export interface UpdateTaskRequest {
 		id: string;
 		title?: string;
 		path?: string[];
+		status?: string;
 		metadata?: TaskMetadata;
 	};
 }

--- a/packages/webview/src/components/kanban/KanbanBoard.tsx
+++ b/packages/webview/src/components/kanban/KanbanBoard.tsx
@@ -105,17 +105,14 @@ export function KanbanBoard() {
 	const handleSaveTask = useCallback(
 		(data: { title: string; status: string; path: string[]; metadata?: TaskMetadata }) => {
 			if (modal.task) {
-				// 編集
+				// 編集（ステータスも含めて一括更新）
 				actions.updateTask({
 					id: modal.task.id,
 					title: data.title,
 					path: data.path,
+					status: data.status,
 					metadata: data.metadata,
 				});
-				// ステータスが変わった場合
-				if (modal.task.status !== data.status) {
-					actions.changeTaskStatus(modal.task.id, data.status);
-				}
 			} else {
 				// 新規作成
 				actions.createTask({

--- a/packages/webview/src/hooks/useVscodeApi.ts
+++ b/packages/webview/src/hooks/useVscodeApi.ts
@@ -227,7 +227,13 @@ export function useKanban() {
 	);
 
 	const updateTask = useCallback(
-		(params: { id: string; title?: string; path?: string[]; metadata?: TaskMetadata }) => {
+		(params: {
+			id: string;
+			title?: string;
+			path?: string[];
+			status?: string;
+			metadata?: TaskMetadata;
+		}) => {
 			postMessage({ type: 'UPDATE_TASK', payload: params });
 		},
 		[postMessage],

--- a/packages/webview/src/types/messages.ts
+++ b/packages/webview/src/types/messages.ts
@@ -71,6 +71,7 @@ export interface UpdateTaskRequest {
 		id: string;
 		title?: string;
 		path?: string[];
+		status?: string;
 		metadata?: TaskMetadata;
 	};
 }


### PR DESCRIPTION
## Summary
- タスク編集モーダルでステータス変更時、`updateTask`と`changeTaskStatus`の並列呼び出しによる競合エラー（"file has changed in the meantime"）を修正
- `UpdateTaskUseCase`にステータス更新機能を追加し、1回のファイル編集で全ての更新が完了するように変更
- WebView側で`changeTaskStatus`の並列呼び出しを削除

## Changes
- `UpdateTaskInput`に`status`フィールドを追加
- `UpdateTaskUseCase`に`ConfigProvider`を注入（チェックボックス連動用）
- メッセージ型定義（core/webview）を更新
- テストケースを追加・修正（227件全てパス）

## Test plan
- [x] 既存のユニットテストがパスすることを確認（227件）
- [ ] タスク編集モーダルでステータスのみを変更してSaveを押し、エラーが発生しないことを確認
- [ ] タスク編集モーダルでタイトル+ステータスを同時に変更してSaveを押し、正常に更新されることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task status can now be updated directly from the Kanban board interface.
  * When a task status changes to "done," the checkbox is automatically synchronized.

* **Tests**
  * Extended test coverage for task status updates and validation.
  * Added tests for checkbox synchronization when task status changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->