### PR TITLE
fix: タスク編集モーダルのボタンラベルをSaveからUpdateに変更

### DIFF
--- a/packages/webview/src/components/kanban/TaskModal.tsx
+++ b/packages/webview/src/components/kanban/TaskModal.tsx
@@ -244,7 +244,7 @@ export function TaskModal({
 									'hover:bg-primary/90 transition-colors',
 								)}
 							>
-								{isEditMode ? 'Save' : 'Create'}
+								{isEditMode ? 'Update' : 'Create'}
 							</button>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary
- タスク編集モーダルのボタンラベルを「Save」から「Update」に変更
- 実際の動作（タスク更新）に合わせた適切なラベルに修正

## Changes
- `packages/webview/src/components/kanban/TaskModal.tsx:247`

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the primary action button label in task edit mode from "Save" to "Update" for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->