### PR TITLE
fix: ステータスをdoneに変更したときにチェックボックスが完了状態になるよう修正

### DIFF
--- a/packages/core/src/bootstrap/di/container.ts
+++ b/packages/core/src/bootstrap/di/container.ts
@@ -103,12 +103,6 @@ export class Container {
 	 * Adaptersを初期化
 	 */
 	private initializeAdapters(): void {
-		// MarkdownTaskRepository
-		this.markdownTaskRepository = new MarkdownTaskRepository(
-			this.markdownTaskClient,
-			this.vscodeDocumentClient,
-		);
-
 		// VscodeConfigProvider
 		this.vscodeConfigProvider = new VscodeConfigProvider(this.vscodeConfigClient);
 
@@ -117,6 +111,13 @@ export class Container {
 			this.markdownTaskClient,
 			this.vscodeDocumentClient,
 			this.vscodeConfigProvider,
+		);
+
+		// MarkdownTaskRepository（ConfigProviderを注入）
+		this.markdownTaskRepository = new MarkdownTaskRepository(
+			this.markdownTaskClient,
+			this.vscodeDocumentClient,
+			this.frontmatterConfigProvider,
 		);
 
 		// VscodeDocumentService


### PR DESCRIPTION
## Summary

- `MarkdownTaskRepository.save()`が`applyEdit()`に`doneStatuses`を渡していなかったため、ステータスを`done`に変更してもチェックボックスが`[x]`にならない問題を修正
- `MarkdownTaskRepository`のコンストラクタに`ConfigProvider`を追加し、設定に基づいてチェックボックスを連動させるよう変更
- DIコンテナの初期化順序を変更（`ConfigProvider`を`MarkdownTaskRepository`より先に初期化）

## Test plan

- [x] 全テストがパスすることを確認（283テスト）
- [x] `todo` → `done` のステータス変更で`doneStatuses`が渡されることを確認するテスト追加
- [x] `syncCheckboxWithDone: false`の場合に`doneStatuses`が渡されないことを確認するテスト追加
- [x] `in-progress` → `done` のステータス変更でも正しく動作することを確認するテスト追加
- [x] ビルドが成功することを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task status configuration settings are now properly applied when saving and editing tasks
  * Done status and checkbox synchronization settings are now correctly respected during task operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->