### PR TITLE
test: テストカバレッジを大幅に拡充 (83%→91%)

### DIFF
--- a/packages/core/src/bootstrap/webview/kanbanPanelProvider.test.ts
+++ b/packages/core/src/bootstrap/webview/kanbanPanelProvider.test.ts
@@ -360,7 +360,7 @@ describe('KanbanPanelProvider', () => {
 			});
 		});
 
-		it('タスク取得失敗時、何も送信しない', async () => {
+		it('タスク取得失敗時、TASKS_UPDATEDは送信せずDOCUMENT_STATE_CHANGEDのみ送信する', async () => {
 			mockContainer.getTaskController = vi.fn(() => ({
 				getTasks: vi.fn().mockResolvedValue({ isOk: () => false, error: new Error('Failed') }),
 			})) as unknown as typeof mockContainer.getTaskController;
@@ -378,10 +378,15 @@ describe('KanbanPanelProvider', () => {
 			};
 			await activeEditorChangeCallback?.(mockEditor);
 
-			// TASKS_UPDATEDは送信されない（DOCUMENT_STATE_CHANGEDのみ送信される）
+			// TASKS_UPDATEDは送信されない
 			expect(mockWebview.postMessage).not.toHaveBeenCalledWith(
 				expect.objectContaining({ type: 'TASKS_UPDATED' }),
 			);
+			// DOCUMENT_STATE_CHANGEDは送信される
+			expect(mockWebview.postMessage).toHaveBeenCalledWith({
+				type: 'DOCUMENT_STATE_CHANGED',
+				payload: { isDirty: false },
+			});
 		});
 	});
 

--- a/packages/core/src/extension.test.ts
+++ b/packages/core/src/extension.test.ts
@@ -161,9 +161,12 @@ describe('extension', () => {
 
 		it('activateされていない場合もエラーにならない', async () => {
 			const extension = await import('./extension');
+			mockDispose.mockClear();
 
 			// deactivateを直接呼び出してもエラーにならないことを確認
 			expect(() => extension.deactivate()).not.toThrow();
+			// activateされていないのでdisposeは呼ばれない
+			expect(mockDispose).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/core/src/interface/adapters/webViewMessageHandler.test.ts
+++ b/packages/core/src/interface/adapters/webViewMessageHandler.test.ts
@@ -336,11 +336,16 @@ describe('WebViewMessageHandler', () => {
 		});
 
 		describe('unknown message type', () => {
-			it('不明なメッセージタイプの場合、例外を発生させずに処理を完了する', async () => {
+			it('不明なメッセージタイプの場合、エラーログを出力して処理を完了する', async () => {
+				const { logger } = await import('../../shared/logger');
+				const loggerSpy = vi.spyOn(logger, 'error');
+
 				const message = { type: 'UNKNOWN_TYPE' } as unknown as WebViewToExtensionMessage;
 
-				// エラーにならずに処理が完了することを確認
 				await expect(handler.handleMessage(message)).resolves.not.toThrow();
+				expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown message type'));
+
+				loggerSpy.mockRestore();
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

- extension.ts のエントリーポイントテストを新規追加（activate/deactivate関数のテスト）
- webViewMessageHandler.ts の SAVE_DOCUMENT/REVERT_DOCUMENT 処理のテストを追加
- kanbanPanelProvider.ts のドキュメント監視・タスク更新通知のテストを追加

## カバレッジ改善

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Statements | 83.79% | 91.22% | +7.43% |
| Branches | 72.06% | 79.74% | +7.68% |
| Functions | 85.02% | 90.28% | +5.26% |
| Lines | 83.61% | 91.27% | +7.66% |

## 追加されたテスト (39件)

### extension.test.ts (新規作成: 10件)
- activate: KanbanPanelProviderの作成
- activate: markdownKanban.openBoardコマンドの登録
- activate: markdownKanban.openBoardFromEditorコマンドの登録
- activate: コマンドのsubscriptions追加
- activate: openBoardコマンド実行時のshowOrCreate呼び出し
- activate: openBoardFromEditorコマンド実行時のshowOrCreate呼び出し
- deactivate: パネルプロバイダーの破棄
- deactivate: DIコンテナの破棄
- deactivate: 未activate時のエラーハンドリング

### kanbanPanelProvider.test.ts (追加: 21件)
- setupDocumentWatcher: アクティブエディタ変更時のURI更新
- setupDocumentWatcher: 非Markdownファイルのスキップ
- setupDocumentWatcher: エディタなし時のスキップ
- ドキュメント変更時のタスク・ドキュメント状態送信
- ドキュメント保存時のドキュメント状態送信
- sendTasksUpdate: タスク取得成功/失敗時の処理
- sendDocumentStateUpdate: isDirty状態の送信
- isMarkdownDocument: 判定ロジック
- getNonce: 32文字英数字生成、ユニーク性
- getHtmlForWebview: スクリプト/スタイル/CSP/nonceの生成

### webViewMessageHandler.test.ts (追加: 8件)
- SAVE_DOCUMENT: documentControllerなし時のエラー
- SAVE_DOCUMENT: 保存成功時のisDirty送信
- SAVE_DOCUMENT: 保存失敗時のエラー送信
- REVERT_DOCUMENT: documentControllerなし時のエラー
- REVERT_DOCUMENT: 破棄成功時の処理（isDirty送信＋タスク再取得）
- REVERT_DOCUMENT: 破棄失敗時のエラー送信
- sendError: NoActiveEditorError/NoActiveDocumentErrorのハンドリング
- unknown message type: エラーログ出力

## Test plan

- [x] `pnpm run test` - 全335件のテストがパス
- [x] `pnpm run test:coverage` - カバレッジ閾値を満たすことを確認
- [x] `pnpm run ci` - CI用チェック（型チェック + Lint + テスト）がパス


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Expanded test coverage for kanban panel operations, including event handling and document state management
  - Added comprehensive tests for extension lifecycle (activation/deactivation flows)
  - Introduced test suite for document save and revert operations
  - Added error handling verification and edge case coverage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->