### PR TITLE
fix: extension.test.tsのテスト分離問題を修正

### DIFF
--- a/packages/core/src/extension.test.ts
+++ b/packages/core/src/extension.test.ts
@@ -43,6 +43,7 @@ describe('extension', () => {
 	};
 
 	beforeEach(async () => {
+		vi.resetModules();
 		vi.clearAllMocks();
 		registeredCommands = new Map();
 


### PR DESCRIPTION
## Summary

- `extension.test.ts`の`beforeEach`に`vi.resetModules()`を追加し、テスト間のモジュール状態分離を保証

## 背景

`extension.ts`にはモジュールレベルの変数`kanbanPanelProvider`が存在し、テスト間で状態が共有される潜在的リスクがあった。現状は各テストで`activate()`→`deactivate()`を呼び出しているため問題が顕在化していないが、テスト順序の変更や新規テスト追加時に不具合が発生する可能性があった。

## 変更内容

```typescript
beforeEach(async () => {
	vi.resetModules();  // 追加
	vi.clearAllMocks();
	// ...
});
```

## Test plan

- [x] `pnpm test` で全225件のテストがパス

Fixes #44
