### PR TITLE
fix: correct CHANGELOG date to 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the "markdown-kanban" extension will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2024-12-29
+## [0.1.0] - 2025-12-29
 
 ### Added
 


### PR DESCRIPTION
## Summary

- Fix typo in CHANGELOG.md: 2024-12-29 → 2025-12-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)