### PR TITLE
fix: .vscodeignoreにセキュリティ上重要なファイルを追加

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,8 +5,11 @@ node_modules/**
 **/node_modules/**
 packages/**/src/**
 packages/**/coverage/**
+packages/**/package.json
+packages/**/tsconfig.tsbuildinfo
 src/**
 docs/**
+examples/**
 .gitignore
 .yarnrc
 esbuild.js
@@ -21,6 +24,9 @@ vsc-extension-quickstart.md
 **/*.tsx
 **/.vscode-test.*
 .devbox/**
+.local/**
+.claude/**
+.github/**
 pnpm-lock.yaml
 pnpm-workspace.yaml
 devbox.json


### PR DESCRIPTION
## Summary

- VSIXパッケージに機密情報やローカル設定が含まれないよう.vscodeignoreを修正

## 追加した除外パターン

| パターン | 理由 |
|---------|------|
| `.local/**` | PAT等の機密情報 |
| `.claude/**` | Claude Codeのローカル設定 |
| `.github/**` | GitHub Actionsワークフロー（拡張機能に不要） |
| `examples/**` | サンプルファイル（拡張機能に不要） |
| `packages/**/package.json` | 不要なメタデータ |
| `packages/**/tsconfig.tsbuildinfo` | ビルド成果物 |

## Test plan

- [ ] `pnpm vsce ls --tree` で除外されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)