### PR TITLE
release: v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,4 @@ jobs:
             ./md-tasks-${{ steps.version.outputs.version }}.vsix
 
       - name: Publish to VS Code Marketplace
-        if: ${{ secrets.VSCE_PAT != '' }}
-        run: pnpm vsce publish --no-dependencies
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: pnpm vsce publish --no-dependencies -p ${{ secrets.VSCE_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the "md-tasks" extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-12-29
+
+### Changed
+
+- Rename package from `markdown-kanban` to `md-tasks`
+  - Command IDs: `markdownKanban.*` → `mdTasks.*`
+  - Settings keys: `markdownKanban.*` → `mdTasks.*`
+
+### Fixed
+
+- Exclude unnecessary files from VSIX package
+
 ## [0.1.0] - 2025-12-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "md-tasks",
   "displayName": "MD Tasks",
   "description": "View and manage TODO lists in Markdown files as a Kanban board",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "kyuki3rain",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

v0.1.1 リリース

## Changes

### Changed
- Rename package from `markdown-kanban` to `md-tasks`
  - Command IDs: `markdownKanban.*` → `mdTasks.*`
  - Settings keys: `markdownKanban.*` → `mdTasks.*`

### Fixed
- Exclude unnecessary files from VSIX package

## Test plan

- [x] 型チェック通過
- [x] 全テスト通過
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)