### PR TITLE
ci: VSCodeテスト環境のキャッシュを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,11 @@ jobs:
       - name: Compile E2E tests
         run: pnpm run compile-tests
 
+      - name: Cache VSCode test installation
+        uses: actions/cache@v4
+        with:
+          path: packages/core/.vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('packages/core/.vscode-test.mjs') }}
+
       - name: Run E2E tests
         run: xvfb-run -a pnpm --filter @md-tasks/core exec vscode-test


### PR DESCRIPTION
## Summary

- E2Eテスト実行時のVSCodeダウンロード（約150MB）をキャッシュし、CI時間を短縮

## 変更内容

```yaml
- name: Cache VSCode test installation
  uses: actions/cache@v4
  with:
    path: packages/core/.vscode-test
    key: vscode-test-${{ runner.os }}-${{ hashFiles('packages/core/.vscode-test.mjs') }}
```

## 効果

- 初回: キャッシュなし（VSCodeをダウンロード）
- 2回目以降: キャッシュヒット（ダウンロードをスキップ、推定30秒〜1分短縮）

## Test plan

- [ ] CIでキャッシュが作成される（初回実行）
- [ ] 2回目以降のCIでキャッシュがヒットする

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)