### PR TITLE
feat: キーボードショートカットによる保存機能を追加

### DIFF
--- a/packages/webview/src/components/kanban/KanbanBoard.tsx
+++ b/packages/webview/src/components/kanban/KanbanBoard.tsx
@@ -8,7 +8,7 @@ import {
 	useSensors,
 } from '@dnd-kit/core';
 import { AlertCircle, Loader2, RefreshCw } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useKanban } from '../../hooks/useVscodeApi';
 import { cn } from '../../lib/utils';
 import type { TaskDto, TaskMetadata } from '../../types';
@@ -45,6 +45,21 @@ export function KanbanBoard() {
 			},
 		}),
 	);
+
+	// キーボードショートカットによる保存（Ctrl+S / Cmd+S）
+	// モーダル表示中、ローディング中、エラー時は無視
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (modal.isOpen || isLoading || error) return;
+
+			if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+				e.preventDefault();
+				actions.saveDocument();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [actions, modal.isOpen, isLoading, error]);
 
 	// ドラッグ開始
 	const handleDragStart = useCallback((event: DragStartEvent) => {


### PR DESCRIPTION
## Summary

- WebView上でCtrl+S（macOSではCmd+S）を押すとドキュメントを保存できるようにした
- モーダル表示中、ローディング中、エラー表示中はショートカットを無視する

## Test plan

- [ ] WebViewでCtrl+S / Cmd+Sを押して保存されることを確認
- [ ] Dirty状態でない場合も問題なく動作することを確認
- [ ] TaskModal表示中にCtrl+Sを押しても保存されないことを確認
- [ ] ローディング中、エラー表示中にCtrl+Sを押しても保存されないことを確認

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)